### PR TITLE
Use framebuffers to implement video output

### DIFF
--- a/glsl/screen_fragment.glsl
+++ b/glsl/screen_fragment.glsl
@@ -1,0 +1,11 @@
+#version 450 core
+
+in vec2 fragment_frame_buffer_point;
+
+uniform sampler2D frame_buffer_texture;
+
+out vec4 fragment_color;
+
+void main() {
+    fragment_color = texture(frame_buffer_texture, fragment_frame_buffer_point);
+}

--- a/glsl/screen_full_vram_vertex.glsl
+++ b/glsl/screen_full_vram_vertex.glsl
@@ -1,0 +1,13 @@
+#version 450 core
+
+in vec2 vertex_point;
+in vec2 frame_buffer_point;
+
+out vec2 fragment_frame_buffer_point;
+
+void main() {
+    gl_Position = vec4(vertex_point.x, vertex_point.y, 0.0, 1.0);
+    float frame_buffer_point_x = float(frame_buffer_point.x) - 1.0;
+    float frame_buffer_point_y = 1.0 - float(frame_buffer_point.y);
+    fragment_frame_buffer_point = vec2(frame_buffer_point_x, frame_buffer_point_y);
+}

--- a/glsl/screen_vertex.glsl
+++ b/glsl/screen_vertex.glsl
@@ -1,0 +1,11 @@
+#version 450 core
+
+in vec2 vertex_point;
+in vec2 frame_buffer_point;
+
+out vec2 fragment_frame_buffer_point;
+
+void main() {
+    gl_Position = vec4(vertex_point.x, vertex_point.y, 0.0, 1.0);
+    fragment_frame_buffer_point = frame_buffer_point;
+}

--- a/glsl/screen_vertex.glsl
+++ b/glsl/screen_vertex.glsl
@@ -7,5 +7,7 @@ out vec2 fragment_frame_buffer_point;
 
 void main() {
     gl_Position = vec4(vertex_point.x, vertex_point.y, 0.0, 1.0);
-    fragment_frame_buffer_point = frame_buffer_point;
+    float frame_buffer_point_x = (float(frame_buffer_point.x) / 1024) - 1.0;
+    float frame_buffer_point_y = 1.0 - (float(frame_buffer_point.y) / 512);
+    fragment_frame_buffer_point = vec2(frame_buffer_point_x, frame_buffer_point_y);
 }

--- a/include/Emulator.hpp
+++ b/include/Emulator.hpp
@@ -34,7 +34,6 @@ public:
 
     CPU* getCPU();
     void emulateFrame();
-    void renderFrame();
     void transferToRAM(std::string path, uint32_t origin, uint32_t size, uint32_t destination);
     void dumpRAM();
 };

--- a/include/Framebuffer.hpp
+++ b/include/Framebuffer.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <memory>
+#include <glad/glad.h>
+#include "Texture.hpp"
+
+class Framebuffer {
+    GLuint object;
+public:
+    Framebuffer(std::unique_ptr<Texture> &texture);
+    ~Framebuffer();
+};

--- a/include/GPU.hpp
+++ b/include/GPU.hpp
@@ -259,6 +259,8 @@ public:
     // TODO: should be private
     void executeGp0(uint32_t value);
     void render();
+    Dimensions getResolution();
+    Point getDisplayAreaStart();
 };
 
 TexturePageColors texturePageColorsWithValue(uint32_t value);

--- a/include/GPUImageBuffer.hpp
+++ b/include/GPUImageBuffer.hpp
@@ -2,7 +2,9 @@
 #include <cstdint>
 #include <tuple>
 
-const uint32_t VRAM_SIZE = (1024 * 512) / sizeof(uint16_t);
+const uint32_t VRAM_WIDTH = 1024;
+const uint32_t VRAM_HEIGHT = 512;
+const uint32_t VRAM_SIZE = (VRAM_WIDTH * VRAM_HEIGHT) / sizeof(uint16_t);
 
 class GPUImageBuffer {
     uint16_t destinationX;

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -19,7 +19,7 @@ class Renderer {
 
     std::unique_ptr<RendererBuffer<Vertex>> buffer;
 
-    std::unique_ptr<Texture> frameBufferTexture;
+    std::unique_ptr<Texture> loadImageTexture;
     std::unique_ptr<RendererProgram> textureRendererProgram;
     std::unique_ptr<RendererBuffer<Point>> textureBuffer;
 

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -9,6 +9,8 @@
 #include "GPUImageBuffer.hpp"
 #include "Texture.hpp"
 
+class GPU;
+
 class Renderer {
     SDL_GLContext glContext;
     SDL_Window *window;
@@ -37,6 +39,6 @@ public:
     void setDrawingOffset(int16_t x, int16_t y);
     void prepareFrame();
     void renderFrame();
-    void finalizeFrame();
+    void finalizeFrame(GPU *gpu);
     void loadImage(std::unique_ptr<GPUImageBuffer> &imageBuffer);
 };

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -29,6 +29,8 @@ class Renderer {
     std::unique_ptr<RendererBuffer<Pixel>> screenBuffer;
 
     GLenum mode;
+    bool resizeToFitFramebuffer;
+
     void checkForceDraw(uint verticesToRender, GLenum newMode);
 public:
     Renderer();

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -13,15 +13,18 @@ class Renderer {
     SDL_GLContext glContext;
     SDL_Window *window;
 
-    std::unique_ptr<RendererProgram> program;
-
     GLuint offsetUniform;
 
+    std::unique_ptr<RendererProgram> program;
     std::unique_ptr<RendererBuffer<Vertex>> buffer;
 
     std::unique_ptr<Texture> loadImageTexture;
     std::unique_ptr<RendererProgram> textureRendererProgram;
     std::unique_ptr<RendererBuffer<Point>> textureBuffer;
+
+    std::unique_ptr<Texture> screenTexture;
+    std::unique_ptr<RendererProgram> screenRendererProgram;
+    std::unique_ptr<RendererBuffer<Pixel>> screenBuffer;
 
     GLenum mode;
     void checkForceDraw(uint verticesToRender, GLenum newMode);
@@ -32,6 +35,8 @@ public:
     void pushLine(std::vector<Vertex> vertices);
     void pushPolygon(std::vector<Vertex> vertices);
     void setDrawingOffset(int16_t x, int16_t y);
-    void display();
+    void prepareFrame();
+    void renderFrame();
+    void finalizeFrame();
     void loadImage(std::unique_ptr<GPUImageBuffer> &imageBuffer);
 };

--- a/include/TestRunner.hpp
+++ b/include/TestRunner.hpp
@@ -44,6 +44,9 @@ class TestRunner {
     uint32_t destinationAddress();
     uint32_t fileSize();
 
+    bool checkOption(char** begin, char** end, const std::string &option);
+    char* getOptionValue(char** begin, char** end, const std::string &option);
+
     TestRunner();
 public:
     static TestRunner* getInstance();

--- a/include/TestRunner.hpp
+++ b/include/TestRunner.hpp
@@ -35,6 +35,7 @@ class TestRunner {
 
     Emulator *emulator;
     bool runTests;
+    bool resizeToFitFramebuffer;
     std::string exeFile;
     uint8_t header[TEST_HEADER_SIZE];
 
@@ -54,6 +55,7 @@ public:
     void configure(int argc, char* argv[]);
     void setEmulator(Emulator *emulator);
     bool shouldRunTests();
+    bool shouldResizeWindowToFitFramebuffer();
     uint32_t programCounter();
     uint32_t globalPointer();
     uint32_t initialStackFramePointerBase();

--- a/include/Texture.hpp
+++ b/include/Texture.hpp
@@ -12,5 +12,9 @@ public:
     Texture(GLsizei width, GLsizei height);
     ~Texture();
 
+    GLuint getID();
+    GLsizei getWidth();
+    GLsizei getHeight();
+    void bind(GLenum texture);
     void setImageFromBuffer(std::unique_ptr<GPUImageBuffer> &imageBuffer);
 };

--- a/include/Vertex.hpp
+++ b/include/Vertex.hpp
@@ -43,8 +43,18 @@ struct Vertex {
     Point texturePage;
     GLuint textureDepthShift;
     Point clut;
-public:
+
     Vertex(Point point, Color color);
     Vertex(Point point, Color color, Point texturePosition, TextureBlendMode textureBlendMode, Point texturePage, GLuint textureDepthShift, Point clut);
     ~Vertex();
+};
+
+struct Pixel {
+    GLfloat pointX;
+    GLfloat pointY;
+    GLfloat framebufferPositionX;
+    GLfloat framebufferPositionY;
+
+    Pixel(GLfloat pointX, GLfloat pointY, GLfloat framebufferPositionX, GLfloat framebufferPositionY);
+    ~Pixel();
 };

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -54,12 +54,9 @@ void Emulator::emulateFrame() {
         if (totalScanlines >= scanlinesPerFrame) {
             interruptController->trigger(VBLANK);
             totalScanlines = 0;
+            gpu->render();
         }
     }
-}
-
-void Emulator::renderFrame() {
-    gpu->render();
 }
 
 void Emulator::transferToRAM(std::string path, uint32_t origin, uint32_t size, uint32_t destination) {

--- a/src/Framebuffer.cpp
+++ b/src/Framebuffer.cpp
@@ -1,0 +1,13 @@
+#include "Framebuffer.hpp"
+
+Framebuffer::Framebuffer(std::unique_ptr<Texture> &texture) {
+    glGenFramebuffers(1, &object);
+    glBindFramebuffer(GL_FRAMEBUFFER, object);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture->getID(), 0);
+    glDrawBuffer(GL_COLOR_ATTACHMENT0);
+    glViewport(0, 0, texture->getWidth(), texture->getHeight());
+}
+
+Framebuffer::~Framebuffer() {
+    glDeleteFramebuffers(1, &object);
+}

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -591,7 +591,39 @@ void GPU::executeGp0(uint32_t value) {
 void GPU::render() {
     renderer.prepareFrame();
     renderer.renderFrame();
-    renderer.finalizeFrame();
+    renderer.finalizeFrame(this);
+}
+
+Dimensions GPU::getResolution() {
+    uint32_t verticalResolution = 240;
+    if (this->verticalResolution == VerticalResolution::Y480) {
+        verticalResolution = 480;
+    }
+    uint8_t horizontalResolutionValue1 = (horizontalResolution >> 1) & 3;
+    uint8_t horizontalResolutionValue2 = horizontalResolution & 1;
+    if (horizontalResolutionValue2 == 1) {
+        return { 368, verticalResolution };
+    } else {
+        switch (horizontalResolutionValue1) {
+            case 0: {
+                return { 256, verticalResolution };
+            }
+            case 1: {
+                return { 320, verticalResolution };
+            }
+            case 2: {
+                return { 512, verticalResolution };
+            }
+            case 3: {
+                return { 640, verticalResolution };
+            }
+        }
+    }
+    return { 0, 0 };
+}
+
+Point GPU::getDisplayAreaStart() {
+    return { (int16_t)displayVRAMStartX, (int16_t)displayVRAMStartY };
 }
 
 void GPU::executeGp1(uint32_t value) {

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -814,7 +814,6 @@ void GPU::operationGp0SetDrawingOffset() {
     int16_t drawingOffsetY = ((int16_t)(y << 5)) >> 5;
 
     renderer.setDrawingOffset(drawingOffsetX, drawingOffsetY);
-    renderer.display();
 }
 
 /*

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -7,7 +7,7 @@ using namespace std;
 const uint32_t GP0_COMMAND_TERMINATION_CODE = 0x55555555;
 
 uint8_t horizontalResolutionFromValues(uint8_t value1, uint8_t value2) {
-    return ((value2 & 1) | (value1 & 3 << 1));
+    return ((value2 & 1) | ((value1 & 3) << 1));
 }
 
 TexturePageColors texturePageColorsWithValue(uint32_t value) {

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -589,7 +589,9 @@ void GPU::executeGp0(uint32_t value) {
 }
 
 void GPU::render() {
-    renderer.display();
+    renderer.prepareFrame();
+    renderer.renderFrame();
+    renderer.finalizeFrame();
 }
 
 void GPU::executeGp1(uint32_t value) {

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -43,7 +43,7 @@ Renderer::Renderer() : mode(GL_TRIANGLES) {
     glUniform2i(offsetUniform, 0, 0);
 
     // TODO: handle resolution for other targets
-    frameBufferTexture = make_unique<Texture>(((GLsizei) width), ((GLsizei) height));
+    loadImageTexture = make_unique<Texture>(((GLsizei) width), ((GLsizei) height));
     checkForOpenGLErrors();
 }
 
@@ -110,7 +110,7 @@ void Renderer::setDrawingOffset(int16_t x, int16_t y) {
 }
 
 void Renderer::loadImage(std::unique_ptr<GPUImageBuffer> &imageBuffer) {
-    frameBufferTexture->setImageFromBuffer(imageBuffer);
+    loadImageTexture->setImageFromBuffer(imageBuffer);
     textureBuffer->clean();
     uint16_t x, y, width, height;
     tie(x, y) = imageBuffer->destination();

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -16,9 +16,7 @@ Renderer::Renderer() : mode(GL_TRIANGLES) {
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 5);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
 
-    int width = 1024;
-    int height = 512;
-    window = SDL_CreateWindow("ルビィ", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, SDL_WINDOW_OPENGL);
+    window = SDL_CreateWindow("ルビィ", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, VRAM_WIDTH, VRAM_HEIGHT, SDL_WINDOW_OPENGL);
     glContext = SDL_GL_CreateContext(window);
 
     if (!gladLoadGLLoader((GLADloadproc) SDL_GL_GetProcAddress)) {
@@ -43,7 +41,7 @@ Renderer::Renderer() : mode(GL_TRIANGLES) {
     glUniform2i(offsetUniform, 0, 0);
 
     // TODO: handle resolution for other targets
-    loadImageTexture = make_unique<Texture>(((GLsizei) width), ((GLsizei) height));
+    loadImageTexture = make_unique<Texture>(((GLsizei) VRAM_WIDTH), ((GLsizei) VRAM_HEIGHT));
     checkForOpenGLErrors();
 }
 

--- a/src/RendererBuffer.cpp
+++ b/src/RendererBuffer.cpp
@@ -108,5 +108,16 @@ void RendererBuffer<Point>::enableAttributes() const {
     glEnableVertexAttribArray(positionIdx);
 }
 
+template <>
+void RendererBuffer<Pixel>::enableAttributes() const {
+    GLuint positionIdx = program->findProgramAttribute("vertex_point");
+    glVertexAttribPointer(positionIdx, 2, GL_FLOAT, GL_FALSE, sizeof(Pixel), (void*)offsetof(struct Pixel, pointX));
+    glEnableVertexAttribArray(positionIdx);
+    GLuint texturePositionIdx = program->findProgramAttribute("frame_buffer_point");
+    glVertexAttribPointer(texturePositionIdx, 2, GL_FLOAT, GL_FALSE, sizeof(Pixel), (void*)offsetof(struct Pixel, framebufferPositionX));
+    glEnableVertexAttribArray(texturePositionIdx);
+}
+
 template class RendererBuffer<Vertex>;
 template class RendererBuffer<Point>;
+template class RendererBuffer<Pixel>;

--- a/src/TestRunner.cpp
+++ b/src/TestRunner.cpp
@@ -1,6 +1,6 @@
 #include "TestRunner.hpp"
-#include <string>
 #include <fstream>
+#include <algorithm>
 #include "Output.hpp"
 #include "CPU.hpp"
 
@@ -17,18 +17,32 @@ TestRunner* TestRunner::getInstance() {
     return instance;
 }
 
+bool TestRunner::checkOption(char** begin, char** end, const std::string &option) {
+    return find(begin, end, option) != end;
+}
+
+char* TestRunner::getOptionValue(char** begin, char** end, const std::string &option) {
+    char **iterator = find(begin, end, option);
+    if (iterator != end && iterator++ != end) {
+        return *iterator;
+    }
+    return NULL;
+}
+
 void TestRunner::configure(int argc, char* argv[]) {
-    if (argc > 2) {
-        string firstArgument = string(argv[1]);
-        if (firstArgument.compare("--exe") == 0) {
-            runTests = true;
-            exeFile = string(argv[2]);
-        } else {
+    if (argc <= 1) {
+        return;
+    }
+    if (checkOption(argv, argv + argc, "--exe")) {
+        char *path = getOptionValue(argv, argv + argc, "--exe");
+        if (path == NULL) {
             printError("Incorrect argument passed. See README.md for usage.");
         }
-    } else if (argc > 1) {
-        printError("Incorrect argument passed. See README.md for usage.");
+        runTests = true;
+        exeFile = string(path);
+        return;
     }
+    printError("Incorrect argument passed. See README.md for usage.");
 }
 
 void TestRunner::setEmulator(Emulator *emulator) {

--- a/src/TestRunner.cpp
+++ b/src/TestRunner.cpp
@@ -42,6 +42,10 @@ void TestRunner::configure(int argc, char* argv[]) {
         exeFile = string(path);
         return;
     }
+    if (checkOption(argv, argv + argc, "--framebuffer")) {
+        resizeToFitFramebuffer = true;
+        return;
+    }
     printError("Incorrect argument passed. See README.md for usage.");
 }
 
@@ -73,6 +77,10 @@ uint32_t TestRunner::loadWord(uint32_t offset) {
 
 bool TestRunner::shouldRunTests() {
     return runTests;
+}
+
+bool TestRunner::shouldResizeWindowToFitFramebuffer() {
+    return resizeToFitFramebuffer;
 }
 
 uint32_t TestRunner::programCounter() {

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-Texture::Texture(GLsizei width, GLsizei height) {
+Texture::Texture(GLsizei width, GLsizei height) : width(width), height(height) {
     glGenTextures(1, &object);
     glBindTexture(GL_TEXTURE_2D, object);
     glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGB5_A1, width, height);
@@ -12,6 +12,23 @@ Texture::Texture(GLsizei width, GLsizei height) {
 
 Texture::~Texture() {
     glDeleteTextures(1, &object);
+}
+
+GLuint Texture::getID() {
+    return object;
+}
+
+GLsizei Texture::getWidth() {
+    return width;
+}
+
+GLsizei Texture::getHeight() {
+    return height;
+}
+
+void Texture::bind(GLenum texture) {
+    glActiveTexture(texture);
+    glBindTexture(GL_TEXTURE_2D, object);
 }
 
 void Texture::setImageFromBuffer(std::unique_ptr<GPUImageBuffer> &imageBuffer) {

--- a/src/Vertex.cpp
+++ b/src/Vertex.cpp
@@ -52,3 +52,7 @@ Vertex::Vertex(Point point, Color color) : point(point), color(color), texturePo
 Vertex::Vertex(Point point, Color color, Point texturePosition, TextureBlendMode textureBlendMode, Point texturePage, GLuint textureDepthShift, Point clut) : point(point), color(color), texturePosition(texturePosition), textureBlendMode(textureBlendMode), texturePage(texturePage), textureDepthShift(textureDepthShift), clut(clut) {}
 
 Vertex::~Vertex() {}
+
+Pixel::Pixel(GLfloat pointX, GLfloat pointY, GLfloat framebufferPositionX, GLfloat framebufferPositionY) : pointX(pointX), pointY(pointY), framebufferPositionX(framebufferPositionX), framebufferPositionY(framebufferPositionY) {}
+
+Pixel::~Pixel() {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,5 @@ int main(int argc, char* argv[]) {
             continue;
         }
         emulator->emulateFrame();
-        emulator->renderFrame();
     }
 }


### PR DESCRIPTION
Instead of displaying the whole VRAM contents:

![Screenshot from 2019-07-16 20 59 52@2x](https://user-images.githubusercontent.com/346590/61321867-af8f7880-a80c-11e9-9a4d-0d72043bb221.png)

display only the video output area using `GPSTAT` attributes: 

![Screenshot from 2019-07-16 21 01 20@2x](https://user-images.githubusercontent.com/346590/61321939-e2397100-a80c-11e9-9eb0-f1a26ad3e055.png)

Use `--framebuffer` to display the whole framebuffer if needed (useful to rule out texture upload problems).