### PR TITLE
Add CD-ROM controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ruby (ルビィ) is a [PlayStation](https://en.wikipedia.org/wiki/PlayStation_(c
 - [x] RAM
 - [x] DMA
 - [x] GPU
-- [ ] CDROM
+- [x] CDROM
 - [x] Interrupts
 - [x] Timers
 - [ ] Controllers and Memory Cards

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -51,6 +51,8 @@ class CDROM {
     void setStatusRegister(uint8_t value);
     void setInterruptRegister(uint8_t value);
     void setInterruptFlagRegister(uint8_t value);
+
+    uint8_t getStatusRegister() const;
 public:
     CDROM();
     ~CDROM();

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -50,17 +50,68 @@ class CDROM {
     CDROMInterrupt interrupt;
 
     std::queue<uint8_t> parameters;
+    std::queue<uint8_t> response;
 
     void setStatusRegister(uint8_t value);
     void setInterruptRegister(uint8_t value);
     void setInterruptFlagRegister(uint8_t value);
+    void execute(uint8_t value);
 
     uint8_t getStatusRegister() const;
 
     void clearParameters();
     void pushParameter(uint8_t value);
+    void pushResponse(uint8_t value);
 
     void updateStatusRegister();
+
+/*
+Command          Parameters      Response(s)
+00h -            -               INT5(11h,40h)  ;reportedly "Sync" uh?
+01h Getstat      -               INT3(stat)
+02h Setloc     E amm,ass,asect   INT3(stat)
+03h Play       E (track)         INT3(stat), optional INT1(report bytes)
+04h Forward    E -               INT3(stat), optional INT1(report bytes)
+05h Backward   E -               INT3(stat), optional INT1(report bytes)
+06h ReadN      E -               INT3(stat), INT1(stat), datablock
+07h MotorOn    E -               INT3(stat), INT2(stat)
+08h Stop       E -               INT3(stat), INT2(stat)
+09h Pause      E -               INT3(stat), INT2(stat)
+0Ah Init         -               INT3(late-stat), INT2(stat)
+0Bh Mute       E -               INT3(stat)
+0Ch Demute     E -               INT3(stat)
+0Dh Setfilter  E file,channel    INT3(stat)
+0Eh Setmode      mode            INT3(stat)
+0Fh Getparam     -               INT3(stat,mode,null,file,channel)
+10h GetlocL    E -               INT3(amm,ass,asect,mode,file,channel,sm,ci)
+11h GetlocP    E -               INT3(track,index,mm,ss,sect,amm,ass,asect)
+12h SetSession E session         INT3(stat), INT2(stat)
+13h GetTN      E -               INT3(stat,first,last)  ;BCD
+14h GetTD      E track (BCD)     INT3(stat,mm,ss)       ;BCD
+15h SeekL      E -               INT3(stat), INT2(stat)  ;\use prior Setloc
+16h SeekP      E -               INT3(stat), INT2(stat)  ;/to set target
+17h -            -               INT5(11h,40h)  ;reportedly "SetClock" uh?
+18h -            -               INT5(11h,40h)  ;reportedly "GetClock" uh?
+19h Test         sub_function    depends on sub_function (see below)
+1Ah GetID      E -               INT3(stat), INT2/5(stat,flg,typ,atip,"SCEx")
+1Bh ReadS      E?-               INT3(stat), INT1(stat), datablock
+1Ch Reset        -               INT3(stat), Delay
+1Dh GetQ       E adr,point       INT3(stat), INT2(10bytesSubQ,peak_lo) ;\not
+1Eh ReadTOC      -               INT3(late-stat), INT2(stat)           ;/vC0
+1Fh VideoCD      sub,a,b,c,d,e   INT3(stat,a,b,c,d,e)   ;<-- SCPH-5903 only
+1Fh..4Fh -       -               INT5(11h,40h)  ;-Unused/invalid
+50h Secret 1     -               INT5(11h,40h)  ;\
+51h Secret 2     "Licensed by"   INT5(11h,40h)  ;
+52h Secret 3     "Sony"          INT5(11h,40h)  ; Secret Unlock Commands
+53h Secret 4     "Computer"      INT5(11h,40h)  ; (not in version vC0, and,
+54h Secret 5     "Entertainment" INT5(11h,40h)  ; nonfunctional in japan)
+55h Secret 6     "<region>"      INT5(11h,40h)  ;
+56h Secret 7     -               INT5(11h,40h)  ;/
+57h SecretLock   -               INT5(11h,40h)  ;-Secret Lock Command
+58h..5Fh Crash   -               Crashes the HC05 (jumps into a data area)
+6Fh..FFh -       -               INT5(11h,40h)  ;-Unused/invalid
+*/
+    void operationTest();
 public:
     CDROM();
     ~CDROM();

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -1,10 +1,36 @@
 #pragma once
 #include <cstdint>
 
-class CDROM {
-    uint8_t index;
+/*
+1F801800h - Index/Status Register (Bit0-1 R/W) (Bit2-7 Read Only)
+0-1 Index   Port 1F801801h-1F801803h index (0..3 = Index0..Index3)   (R/W)
+2   ADPBUSY XA-ADPCM fifo empty  (0=Empty) ;set when playing XA-ADPCM sound
+3   PRMEMPT Parameter fifo empty (1=Empty) ;triggered before writing 1st byte
+4   PRMWRDY Parameter fifo full  (0=Full)  ;triggered after writing 16 bytes
+5   RSLRRDY Response fifo empty  (0=Empty) ;triggered after reading LAST byte
+6   DRQSTS  Data fifo empty      (0=Empty) ;triggered after reading LAST byte
+7   BUSYSTS Command/parameter transmission busy  (1=Busy)
+*/
+union CDROMStatus {
+    struct {
+        uint8_t index : 2;
+        uint8_t XAADCPMFifoEmpty : 1;
+        uint8_t parameterFifoEmpty : 1;
+        uint8_t parameterFifoFull : 1;
+        uint8_t responseFifoEmpty : 1;
+        uint8_t dataFifoEmpty : 1;
+        uint8_t transmissionBusy : 1;
+    };
 
-    void setIndex(uint8_t index);
+    uint8_t _value;
+
+    CDROMStatus() : _value(0) {}
+};
+
+class CDROM {
+    CDROMStatus status;
+
+    void setStatusRegister(uint8_t value);
 public:
     CDROM();
     ~CDROM();

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -50,6 +50,7 @@ class CDROM {
 
     void setStatusRegister(uint8_t value);
     void setInterruptRegister(uint8_t value);
+    void setInterruptFlagRegister(uint8_t value);
 public:
     CDROM();
     ~CDROM();

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -121,6 +121,8 @@ Command          Parameters      Response(s)
 6Fh..FFh -       -               INT5(11h,40h)  ;-Unused/invalid
 */
     void operationTest();
+
+    void operationGetstat();
 public:
     CDROM(std::unique_ptr<InterruptController> &interruptController);
     ~CDROM();

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <queue>
 
 /*
 1F801800h - Index/Status Register (Bit0-1 R/W) (Bit2-7 Read Only)
@@ -48,11 +49,18 @@ class CDROM {
     CDROMStatus status;
     CDROMInterrupt interrupt;
 
+    std::queue<uint8_t> parameters;
+
     void setStatusRegister(uint8_t value);
     void setInterruptRegister(uint8_t value);
     void setInterruptFlagRegister(uint8_t value);
 
     uint8_t getStatusRegister() const;
+
+    void clearParameters();
+    void pushParameter(uint8_t value);
+
+    void updateStatusRegister();
 public:
     CDROM();
     ~CDROM();

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -24,7 +24,7 @@ union CDROMStatus {
 
     uint8_t _value;
 
-    CDROMStatus() : _value(0) {}
+    CDROMStatus() : _value(0x18) {}
 };
 
 /*

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -67,6 +67,8 @@ class CDROM {
     uint8_t getReponse();
 
     void clearParameters();
+    void clearInterruptQueue();
+    void clearResponse();
     void pushParameter(uint8_t value);
     void pushResponse(uint8_t value);
 

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <cstdint>
 #include <queue>
+#include <memory>
+#include "InterruptController.hpp"
 
 /*
 1F801800h - Index/Status Register (Bit0-1 R/W) (Bit2-7 Read Only)
@@ -46,11 +48,14 @@ union CDROMInterrupt {
 };
 
 class CDROM {
+    std::unique_ptr<InterruptController> &interruptController;
+
     CDROMStatus status;
     CDROMInterrupt interrupt;
 
     std::queue<uint8_t> parameters;
     std::queue<uint8_t> response;
+    std::queue<uint8_t> interruptQueue;
 
     void setStatusRegister(uint8_t value);
     void setInterruptRegister(uint8_t value);
@@ -113,8 +118,10 @@ Command          Parameters      Response(s)
 */
     void operationTest();
 public:
-    CDROM();
+    CDROM(std::unique_ptr<InterruptController> &interruptController);
     ~CDROM();
+
+    void step();
 
     template <typename T>
     inline T load(uint32_t offset) const;

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -64,6 +64,7 @@ class CDROM {
 
     uint8_t getStatusRegister() const;
     uint8_t getInterruptFlagRegister() const;
+    uint8_t getReponse();
 
     void clearParameters();
     void pushParameter(uint8_t value);
@@ -125,7 +126,7 @@ public:
     void step();
 
     template <typename T>
-    inline T load(uint32_t offset) const;
+    inline T load(uint32_t offset);
     template <typename T>
     inline void store(uint32_t offset, T value);
 };

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -63,6 +63,7 @@ class CDROM {
     void execute(uint8_t value);
 
     uint8_t getStatusRegister() const;
+    uint8_t getInterruptFlagRegister() const;
 
     void clearParameters();
     void pushParameter(uint8_t value);

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -27,10 +27,29 @@ union CDROMStatus {
     CDROMStatus() : _value(0) {}
 };
 
+/*
+1F801803h.Index0 - Interrupt Enable Register (R)
+1F801803h.Index2 - Interrupt Enable Register (R) (Mirror)
+0-4  Interrupt Enable Bits (usually all set, ie. 1Fh=Enable All IRQs)
+5-7  Unknown/unused (write: should be zero) (read: usually all bits set)
+*/
+union CDROMInterrupt {
+    struct {
+        uint8_t enable : 4;
+        uint8_t unknown : 4;
+    };
+
+    uint8_t _value;
+
+    CDROMInterrupt() : _value(0) {}
+};
+
 class CDROM {
     CDROMStatus status;
+    CDROMInterrupt interrupt;
 
     void setStatusRegister(uint8_t value);
+    void setInterruptRegister(uint8_t value);
 public:
     CDROM();
     ~CDROM();

--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -33,6 +33,10 @@ inline void CDROM::store(uint32_t offset, T value) {
         }
         case 2: {
             switch (status.index) {
+                case 0: {
+                    pushParameter(value);
+                    break;
+                }
                 case 1: {
                     setInterruptRegister(value);
                     break;

--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -3,7 +3,7 @@
 #include "Output.hpp"
 
 template <typename T>
-inline T CDROM::load(uint32_t offset) const {
+inline T CDROM::load(uint32_t offset) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 1) {
         printError("Unsupported CDROM read with size: %d", sizeof(T));
@@ -11,6 +11,18 @@ inline T CDROM::load(uint32_t offset) const {
     switch (offset) {
         case 0: {
             return getStatusRegister();
+        }
+        case 1: {
+            switch (status.index) {
+                case 1: {
+                    return getReponse();
+                }
+                default: {
+                   printError("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
+                   break;
+                }
+            }
+            break;
         }
         case 3: {
             switch (status.index) {

--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -12,8 +12,21 @@ inline T CDROM::load(uint32_t offset) const {
         case 0: {
             return getStatusRegister();
         }
+        case 3: {
+            switch (status.index) {
+                case 1: {
+                    return getInterruptFlagRegister();
+                }
+                default: {
+                   printError("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
+                   break;
+                }
+            }
+            break;
+        }
         default: {
-            printError("Unhandled CDROM read at offset: %#x", offset);
+            printError("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index);
+            break;
         }
     }
     return 0;

--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -35,7 +35,7 @@ inline void CDROM::store(uint32_t offset, T value) {
         case 2: {
             switch (status.index) {
                 case 1: {
-                    printWarning("Unhandled CDROM Interrupt Enable Register");
+                    setInterruptRegister(value);
                     break;
                 }
                 default: {

--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -31,6 +31,10 @@ inline void CDROM::store(uint32_t offset, T value) {
             setStatusRegister(param);
             break;
         }
+        case 1: {
+            execute(value);
+            break;
+        }
         case 2: {
             switch (status.index) {
                 case 0: {

--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -29,37 +29,37 @@ inline void CDROM::store(uint32_t offset, T value) {
     uint8_t param = value & 0xFF;
     switch (offset) {
         case 0: {
-            setIndex(param);
+            setStatusRegister(param);
             break;
         }
         case 2: {
-            switch (index) {
+            switch (status.index) {
                 case 1: {
                     printWarning("Unhandled CDROM Interrupt Enable Register");
                     break;
                 }
                 default: {
-                    printError("Unhandled CDROM write at offset: %#x, with index: %d", offset, index);
+                    printError("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
                     break;
                 }
             }
             break;
         }
         case 3: {
-            switch (index) {
+            switch (status.index) {
                 case 1: {
                     printWarning("Unhandled CDROM Interrupt Flag Register");
                     break;
                 }
                 default: {
-                    printError("Unhandled CDROM write at offset: %#x, with index: %d", offset, index);
+                    printError("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
                     break;
                 }
             }
             break;
         }
         default: {
-            printError("Unhandled CDROM write at offset: %#x, with index: %d", offset, index);
+            printError("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
             break;
         }
     }

--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -48,7 +48,7 @@ inline void CDROM::store(uint32_t offset, T value) {
         case 3: {
             switch (status.index) {
                 case 1: {
-                    printWarning("Unhandled CDROM Interrupt Flag Register");
+                    setInterruptFlagRegister(value);
                     break;
                 }
                 default: {

--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -10,7 +10,7 @@ inline T CDROM::load(uint32_t offset) const {
     }
     switch (offset) {
         case 0: {
-            return status._value;
+            return getStatusRegister();
         }
         default: {
             printError("Unhandled CDROM read at offset: %#x", offset);

--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -10,8 +10,7 @@ inline T CDROM::load(uint32_t offset) const {
     }
     switch (offset) {
         case 0: {
-            printWarning("Unhandled CDROM Status Register");
-            return 0;
+            return status._value;
         }
         default: {
             printError("Unhandled CDROM read at offset: %#x", offset);

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -23,3 +23,7 @@ void CDROM::setInterruptFlagRegister(uint8_t value) {
         // TODO: Reset parameter FIFO
     }
 }
+
+uint8_t CDROM::getStatusRegister() const {
+    return status._value;
+}

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-CDROM::CDROM() : status(), parameters() {
+CDROM::CDROM() : status(), parameters(), response() {
 
 }
 
@@ -27,6 +27,20 @@ void CDROM::setInterruptFlagRegister(uint8_t value) {
     }
 }
 
+void CDROM::execute(uint8_t value) {
+    switch (value) {
+        case 0x19: {
+            operationTest();
+            break;
+        }
+        default: {
+            printError("Unhandled CDROM operation value: %#x", value);
+        }
+    }
+    clearParameters();
+    updateStatusRegister();
+}
+
 uint8_t CDROM::getStatusRegister() const {
     return status._value;
 }
@@ -44,7 +58,80 @@ void CDROM::pushParameter(uint8_t value) {
     updateStatusRegister();
 }
 
+void CDROM::pushResponse(uint8_t value) {
+    if (response.size() >= 16) {
+        printError("Response FIFO full");
+    }
+    response.push(value);
+    updateStatusRegister();
+}
+
 void CDROM::updateStatusRegister() {
     status.parameterFifoEmpty = parameters.empty();
     status.parameterFifoFull = !(parameters.size() >= 16);
+    status.responseFifoEmpty = !response.empty();
+}
+
+/*
+sub  params  response           ;Effect
+00h      -   INT3(stat)         ;Force motor on, clockwise, even if door open
+01h      -   INT3(stat)         ;Force motor on, anti-clockwise, super-fast
+02h      -   INT3(stat)         ;Force motor on, anti-clockwise, super-fast
+03h      -   INT3(stat)         ;Force motor off (ignored during spin-up)
+04h      -   INT3(stat)         ;Start SCEx reading and reset counters
+05h      -   INT3(total,success);Stop SCEx reading and get counters
+06h *    n   INT3(old)  ;\early ;Adjust balance in RAM, send CX(30+n XOR 7)
+07h *    n   INT3(old)  ; PSX   ;Adjust gain in RAM, send CX(38+n XOR 7)
+08h *    n   INT3(old)  ;/only  ;Adjust balance in RAM only
+06h..0Fh -   INT5(11h,10h)      ;N/A (11h,20h when NONZERO number of params)
+10h      -   INT3(stat) ;CX(..) ;Force motor on, anti-clockwise, super-fast
+11h      -   INT3(stat) ;CX(03) ;Move Lens Up (leave parking position)
+12h      -   INT3(stat) ;CX(02) ;Move Lens Down (enter parking position)
+13h      -   INT3(stat) ;CX(28) ;Move Lens Outwards
+14h      -   INT3(stat) ;CX(2C) ;Move Lens Inwards
+15h      -   INT3(stat) ;CX(22) ;If motor on: Move outwards,inwards,motor off
+16h      -   INT3(stat) ;CX(23) ;No effect?
+17h      -   INT3(stat) ;CX(E8) ;Force motor on, clockwise, super-fast
+18h      -   INT3(stat) ;CX(EA) ;Force motor on, anti-clockwise, super-fast
+19h      -   INT3(stat) ;CX(25) ;No effect?
+1Ah      -   INT3(stat) ;CX(21) ;No effect?
+1Bh..1Fh -   INT5(11h,10h)      ;N/A (11h,20h when NONZERO number of params)
+20h      -   INT3(yy,mm,dd,ver) ;Get cdrom BIOS date/version (yy,mm,dd,ver)
+21h      -   INT3(n)            ;Get Drive Switches (bit0=POS0, bit1=DOOR)
+22h ***  -   INT3("for ...")    ;Get Region ID String
+23h ***  -   INT3("CXD...")     ;Get Chip ID String for Servo Amplifier
+24h ***  -   INT3("CXD...")     ;Get Chip ID String for Signal Processor
+25h ***  -   INT3("CXD...")     ;Get Chip ID String for Decoder/FIFO
+26h..2Fh -   INT5(11h,10h)      ;N/A (11h,20h when NONZERO number of params)
+30h *    i,x,y     INT3(stat)       ;Prototype/Debug stuff   ;\supported on
+31h *    x,y       INT3(stat)       ;Prototype/Debug stuff   ; early PSX only
+4xh *    i         INT3(x,y)        ;Prototype/Debug stuff   ;/
+30h..4Fh ..        INT5(11h,10h)    ;N/A always 11h,10h (no matter of params)
+50h      a[,b[,c]] INT3(stat)       ;Servo/Signal send CX(a:b:c)
+51h **   39h,xx    INT3(stat,hi,lo) ;Servo/Signal send CX(39xx) with response
+51h..5Fh -         INT5(11h,10h)    ;N/A
+60h      lo,hi     INT3(databyte)   ;HC05 SUB-CPU read RAM and I/O ports
+61h..70h -         INT5(11h,10h)    ;N/A
+71h ***  adr       INT3(databyte)   ;Decoder Read one register
+72h ***  adr,dat   INT3(stat)       ;Decoder Write one register
+73h ***  adr,len   INT3(databytes..);Decoder Read multiple registers, bugged
+74h ***  adr,len,..INT3(stat)       ;Decoder Write multiple registers, bugged
+75h ***  -         INT3(lo,hi,lo,hi);Decoder Get Host Xfer Info Remain/Addr
+76h ***  a,b,c,d   INT3(stat)       ;Decoder Prepare Transfer to/from SRAM
+77h..FFh -         INT5(11h,10h)    ;N/A
+*/
+void CDROM::operationTest() {
+    uint8_t subfunction = parameters.front();
+    switch (subfunction) {
+        case 0x20: {
+            pushResponse(0x94); // 148
+            pushResponse(0x09); // 9
+            pushResponse(0x19); // 25
+            pushResponse(0xc0); // 192
+            break;
+        }
+        default: {
+            printError("Unhandled CDROM operation test with subfunction: %#x", subfunction);
+        }
+    }
 }

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -41,6 +41,10 @@ void CDROM::execute(uint8_t value) {
     clearInterruptQueue();
     clearResponse();
     switch (value) {
+        case 0x01: {
+            operationGetstat();
+            break;
+        }
         case 0x19: {
             operationTest();
             break;
@@ -175,4 +179,9 @@ void CDROM::operationTest() {
             printError("Unhandled CDROM operation test with subfunction: %#x", subfunction);
         }
     }
+}
+
+void CDROM::operationGetstat() {
+    pushResponse(status._value);
+    interruptQueue.push(0x3);
 }

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -53,6 +53,14 @@ uint8_t CDROM::getStatusRegister() const {
     return status._value;
 }
 
+uint8_t CDROM::getInterruptFlagRegister() const {
+    uint8_t flags = 0b11100000;
+    if (!interruptQueue.empty()) {
+        flags |= interruptQueue.front() & 0x7;
+    }
+    return flags;
+}
+
 void CDROM::clearParameters() {
     queue<uint8_t> empty;
     swap(parameters, empty);

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -29,9 +29,11 @@ void CDROM::setInterruptRegister(uint8_t value) {
 
 void CDROM::setInterruptFlagRegister(uint8_t value) {
     if (value & 0x40) {
-        status.parameterFifoEmpty = 1;
-        status.parameterFifoFull = 1;
         clearParameters();
+        updateStatusRegister();
+    }
+    if (!interruptQueue.empty()) {
+        interruptQueue.pop();
     }
 }
 

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -11,3 +11,7 @@ CDROM::~CDROM() {
 void CDROM::setStatusRegister(uint8_t value) {
     status.index = value & 0x3;
 }
+
+void CDROM::setInterruptRegister(uint8_t value) {
+    interrupt.enable = value;
+}

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -15,3 +15,11 @@ void CDROM::setStatusRegister(uint8_t value) {
 void CDROM::setInterruptRegister(uint8_t value) {
     interrupt.enable = value;
 }
+
+void CDROM::setInterruptFlagRegister(uint8_t value) {
+    if (value & 0x40) {
+        status.parameterFifoEmpty = 1;
+        status.parameterFifoFull = 1;
+        // TODO: Reset parameter FIFO
+    }
+}

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -61,6 +61,16 @@ uint8_t CDROM::getInterruptFlagRegister() const {
     return flags;
 }
 
+uint8_t CDROM::getReponse() {
+    uint8_t value = 0;
+    if (!response.empty()) {
+        value = response.front();
+        response.pop();
+        updateStatusRegister();
+    }
+    return value;
+}
+
 void CDROM::clearParameters() {
     queue<uint8_t> empty;
     swap(parameters, empty);

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -36,6 +36,8 @@ void CDROM::setInterruptFlagRegister(uint8_t value) {
 }
 
 void CDROM::execute(uint8_t value) {
+    clearInterruptQueue();
+    clearResponse();
     switch (value) {
         case 0x19: {
             operationTest();
@@ -74,6 +76,16 @@ uint8_t CDROM::getReponse() {
 void CDROM::clearParameters() {
     queue<uint8_t> empty;
     swap(parameters, empty);
+}
+
+void CDROM::clearInterruptQueue() {
+    queue<uint8_t> empty;
+    swap(interruptQueue, empty);
+}
+
+void CDROM::clearResponse() {
+    queue<uint8_t> empty;
+    swap(response, empty);
 }
 
 void CDROM::pushParameter(uint8_t value) {

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -1,6 +1,9 @@
 #include "CDROM.hpp"
+#include "Output.hpp"
 
-CDROM::CDROM() : status() {
+using namespace std;
+
+CDROM::CDROM() : status(), parameters() {
 
 }
 
@@ -20,10 +23,28 @@ void CDROM::setInterruptFlagRegister(uint8_t value) {
     if (value & 0x40) {
         status.parameterFifoEmpty = 1;
         status.parameterFifoFull = 1;
-        // TODO: Reset parameter FIFO
+        clearParameters();
     }
 }
 
 uint8_t CDROM::getStatusRegister() const {
     return status._value;
+}
+
+void CDROM::clearParameters() {
+    queue<uint8_t> empty;
+    swap(parameters, empty);
+}
+
+void CDROM::pushParameter(uint8_t value) {
+    if (parameters.size() >= 16) {
+        printError("Parameter FIFO full");
+    }
+    parameters.push(value);
+    updateStatusRegister();
+}
+
+void CDROM::updateStatusRegister() {
+    status.parameterFifoEmpty = parameters.empty();
+    status.parameterFifoFull = !(parameters.size() >= 16);
 }

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -1,6 +1,6 @@
 #include "CDROM.hpp"
 
-CDROM::CDROM() : index() {
+CDROM::CDROM() : status() {
 
 }
 
@@ -8,6 +8,6 @@ CDROM::~CDROM() {
 
 }
 
-void CDROM::setIndex(uint8_t index) {
-    this->index = index & 0x3;
+void CDROM::setStatusRegister(uint8_t value) {
+    status.index = value & 0x3;
 }

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -35,8 +35,8 @@ Emulator::Emulator() : ttyBuffer(), biosFunctionsLog() {
     gpu = make_unique<GPU>(mainWindow);
     dma = make_unique<DMA>(ram, gpu);
     scratchpad = make_unique<Scratchpad>();
-    cdrom = make_unique<CDROM>();
     interruptController = make_unique<InterruptController>(cop0);
+    cdrom = make_unique<CDROM>(interruptController);
     expansion1 = make_unique<Expansion1>();
     timer0 = make_unique<Timer0>();
     timer1 = make_unique<Timer1>();
@@ -66,6 +66,7 @@ void Emulator::emulateFrame() {
             }
             totalSystemClocksThisFrame++;
         }
+        cdrom->step();
         timer0->step(systemClockStep);
         timer1->step(systemClockStep);
         timer2->step(systemClockStep);


### PR DESCRIPTION
This isn't a complete implementation, it's just the foundation for the CD-ROM controller. Currently it's able to trigger the CD-ROM interrupt needed to get out of the:
```
BIOS: TestEvent(event) args: f1000001
BIOS: TestEvent(event) args: f1000002
BIOS: TestEvent(event) args: f1000003
BIOS: TestEvent(event) args: f1000004
BIOS: TestEvent(event) args: f1000005
```
BIOS loop.

This is the somewhat full TTY output:
```
PS-X Realtime Kernel Ver.2.5
Copyright 1993,1994 (C) Sony Computer Entertainment Inc. 
...
KERNEL SETUP!
...
Configuration : EvCB	0x10		TCB	0x04
...
System ROM Version 2.2 12/04/95 A
Copyright 1993,1994,1995 (C) Sony Computer Entertainment Inc.
ResetCallback: _96_remove ..
...
System Controller ROM Version 94/09/19 c0
...
PS-X Control PAD Driver  Ver 3.0
...
Unhandled Geometry Translation Engine instruction: 0x48c8e800 <--- Crash!
```