### PR TITLE
Refactor logger

### DIFF
--- a/include/BIOS.hpp
+++ b/include/BIOS.hpp
@@ -3,11 +3,13 @@
 #include <string>
 #include <optional>
 #include <array>
+#include "Logger.hpp"
 
 const uint32_t BIOS_SIZE = 512*1024;
 
 class BIOS {
     uint8_t data[BIOS_SIZE];
+    Logger logger;
 
     std::string formatBIOSFunction(std::string function, uint argc, std::array<uint32_t, 4> subroutineArguments);
 
@@ -15,7 +17,7 @@ class BIOS {
     std::optional<std::string> checkBFunctions(uint32_t r9, std::array<uint32_t, 4> subroutineArguments);
     std::optional<std::string> checkCFunctions(uint32_t r9, std::array<uint32_t, 4> subroutineArguments);
 public:
-    BIOS();
+    BIOS(LogLevel logLevel);
     ~BIOS();
 
     std::optional<std::string> checkFunctions(uint32_t programCounter, uint32_t r9, std::array<uint32_t, 4> subroutineArguments);

--- a/include/CDImage.hpp
+++ b/include/CDImage.hpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <fstream>
 #include <cstdint>
+#include "Logger.hpp"
 
 const uint32_t SecondsPerMinute = 60;
 const uint32_t SectorsPerSecond = 75;
@@ -28,6 +29,7 @@ struct CDSector {
 
 class CDImage {
     std::ifstream file;
+    Logger logger;
 public:
     CDImage();
     ~CDImage();

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include "InterruptController.hpp"
 #include "CDImage.hpp"
+#include "Logger.hpp"
 
 /*
 INT0   No response received (no interrupt request)
@@ -214,9 +215,9 @@ union CDROMMode {
 };
 
 class CDROM {
+    Logger logger;
     std::unique_ptr<InterruptController> &interruptController;
     CDImage image;
-    bool logActivity;
 
     CDROMStatus status;
     CDROMInterrupt interrupt;
@@ -311,9 +312,8 @@ Command          Parameters      Response(s)
     void operationReadN();
     void operationPause();
     void operationInit();
-    void logMessage(std::string message) const;
 public:
-    CDROM(std::unique_ptr<InterruptController> &interruptController, bool logActivity);
+    CDROM(LogLevel logLevel, std::unique_ptr<InterruptController> &interruptController);
     ~CDROM();
 
     void step();

--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -1,12 +1,11 @@
 #pragma once
 #include "CDROM.hpp"
-#include "Output.hpp"
 
 template <typename T>
 inline T CDROM::load(uint32_t offset) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 1) {
-        logger.logError(format("Unsupported CDROM read with size: %d", sizeof(T)));
+        logger.logError("Unsupported CDROM read with size: %d", sizeof(T));
     }
     switch (offset) {
         case 0: {
@@ -18,7 +17,7 @@ inline T CDROM::load(uint32_t offset) {
                     return getReponse();
                 }
                 default: {
-                   logger.logError(format("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index));
+                   logger.logError("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index);
                    break;
                 }
             }
@@ -39,14 +38,14 @@ inline T CDROM::load(uint32_t offset) {
                     return getInterruptFlagRegister();
                 }
                 default: {
-                   logger.logError(format("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index));
+                   logger.logError("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index);
                    break;
                 }
             }
             break;
         }
         default: {
-            logger.logError(format("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index));
+            logger.logError("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index);
             break;
         }
     }
@@ -57,7 +56,7 @@ template <typename T>
 inline void CDROM::store(uint32_t offset, T value) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 1) {
-        logger.logError(format("Unsupported CDROM write with size: %d", sizeof(T)));
+        logger.logError("Unsupported CDROM write with size: %d", sizeof(T));
     }
     uint8_t param = value & 0xFF;
     switch (offset) {
@@ -80,7 +79,7 @@ inline void CDROM::store(uint32_t offset, T value) {
                     break;
                 }
                 default: {
-                    logger.logError(format("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index));
+                    logger.logError("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
                     break;
                 }
             }
@@ -97,14 +96,14 @@ inline void CDROM::store(uint32_t offset, T value) {
                     break;
                 }
                 default: {
-                    logger.logError(format("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index));
+                    logger.logError("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
                     break;
                 }
             }
             break;
         }
         default: {
-            logger.logError(format("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index));
+            logger.logError("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
             break;
         }
     }

--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -6,7 +6,7 @@ template <typename T>
 inline T CDROM::load(uint32_t offset) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 1) {
-        printError("Unsupported CDROM read with size: %d", sizeof(T));
+        logger.logError(format("Unsupported CDROM read with size: %d", sizeof(T)));
     }
     switch (offset) {
         case 0: {
@@ -18,7 +18,7 @@ inline T CDROM::load(uint32_t offset) {
                     return getReponse();
                 }
                 default: {
-                   printError("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index);
+                   logger.logError(format("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index));
                    break;
                 }
             }
@@ -39,14 +39,14 @@ inline T CDROM::load(uint32_t offset) {
                     return getInterruptFlagRegister();
                 }
                 default: {
-                   printError("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index);
+                   logger.logError(format("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index));
                    break;
                 }
             }
             break;
         }
         default: {
-            printError("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index);
+            logger.logError(format("Unhandled CDROM read at offset: %#x, with index: %d", offset, status.index));
             break;
         }
     }
@@ -57,7 +57,7 @@ template <typename T>
 inline void CDROM::store(uint32_t offset, T value) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 1) {
-        printError("Unsupported CDROM write with size: %d", sizeof(T));
+        logger.logError(format("Unsupported CDROM write with size: %d", sizeof(T)));
     }
     uint8_t param = value & 0xFF;
     switch (offset) {
@@ -80,7 +80,7 @@ inline void CDROM::store(uint32_t offset, T value) {
                     break;
                 }
                 default: {
-                    printError("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
+                    logger.logError(format("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index));
                     break;
                 }
             }
@@ -97,14 +97,14 @@ inline void CDROM::store(uint32_t offset, T value) {
                     break;
                 }
                 default: {
-                    printError("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
+                    logger.logError(format("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index));
                     break;
                 }
             }
             break;
         }
         default: {
-            printError("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
+            logger.logError(format("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index));
             break;
         }
     }

--- a/include/CPU.hpp
+++ b/include/CPU.hpp
@@ -5,6 +5,7 @@
 #include "Instruction.hpp"
 #include "Debugger.hpp"
 #include "COP0.hpp"
+#include "Logger.hpp"
 
 struct LoadSlot {
     uint32_t registerIndex;
@@ -31,6 +32,7 @@ R31        ra       Return address (used so by JAL,BLTZAL,BGEZAL opcodes)
 -          hi,lo    Multiply/divide results, may be changed by subroutines
 */
 class CPU {
+    Logger logger;
     uint32_t programCounter;
     uint32_t jumpDestination;
     bool isBranching;
@@ -132,7 +134,7 @@ class CPU {
 
     void operationIllegal(Instruction instruction);
 public:
-    CPU(std::unique_ptr<Interconnect> &interconnect, std::unique_ptr<COP0> &cop0, bool logBiosFunctionCalls);
+    CPU(LogLevel logLevel, std::unique_ptr<Interconnect> &interconnect, std::unique_ptr<COP0> &cop0, bool logBiosFunctionCalls);
     ~CPU();
 
     std::unique_ptr<COP0>& cop0Ref();

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <optional>
+#include "Logger.hpp"
 
 enum Direction {
     ToRam = 0,
@@ -103,6 +104,7 @@ class Channel {
     ChannelControl control;
     ChannelBaseAddress baseAddress;
     ChannelBlockControl blockControl;
+    Logger logger;
 public:
     Channel();
     ~Channel();

--- a/include/ConfigurationManager.hpp
+++ b/include/ConfigurationManager.hpp
@@ -1,11 +1,22 @@
 #pragma once
 #include <string>
 #include <yaml/Yaml.hpp>
+#include "Logger.hpp"
 
 class ConfigurationManager {
     static ConfigurationManager *instance;
+    Logger logger;
     std::string filePath;
-    Yaml::Node configuration;
+
+    bool resizeWindowToFitFramefuffer;
+    bool showDebugInfoWindow;
+
+    LogLevel bios;
+    LogLevel cdrom;
+    LogLevel interconnect;
+    LogLevel cpu;
+    LogLevel gpu;
+    bool trace;
 
     ConfigurationManager();
 public:
@@ -13,10 +24,14 @@ public:
 
     void setupConfigurationFile();
     void loadConfiguration();
+
     bool shouldResizeWindowToFitFramebuffer();
-    bool shouldLogVerbose();
     bool shouldShowDebugInfoWindow();
-    bool shouldLogBiosFunctionCalls();
-    bool shouldLogCDROMActivity();
+
+    LogLevel biosLogLevel();
+    LogLevel cdromLogLevel();
+    LogLevel interconnectLogLevel();
+    LogLevel cpuLogLevel();
+    LogLevel gpuLogLevel();
     bool shouldTraceLogs();
 };

--- a/include/ConfigurationManager.hpp
+++ b/include/ConfigurationManager.hpp
@@ -16,6 +16,7 @@ class ConfigurationManager {
     LogLevel interconnect;
     LogLevel cpu;
     LogLevel gpu;
+    LogLevel opengl;
     bool trace;
 
     ConfigurationManager();
@@ -33,5 +34,6 @@ public:
     LogLevel interconnectLogLevel();
     LogLevel cpuLogLevel();
     LogLevel gpuLogLevel();
+    LogLevel openGLLogLevel();
     bool shouldTraceLogs();
 };

--- a/include/Controller.hpp
+++ b/include/Controller.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include "Logger.hpp"
 
 /*
 1F80104Ah JOY_CTRL (R/W) (usually 1003h,3003h,0000h)
@@ -140,7 +141,7 @@ union JoypadTxData {
 };
 
 class Controller {
-
+    Logger logger;
 public:
     Controller();
     ~Controller();

--- a/include/Controller.tcc
+++ b/include/Controller.tcc
@@ -1,6 +1,5 @@
 #pragma once
 #include "Controller.hpp"
-#include "Output.hpp"
 
 template <typename T>
 inline T Controller::load(uint32_t offset) {
@@ -16,7 +15,7 @@ inline T Controller::load(uint32_t offset) {
             return getControlRegister();
         }
         default: {
-            logger.logError(format("Unhandled Controller read at offset: %#x", offset));
+            logger.logError("Unhandled Controller read at offset: %#x", offset);
             break;
         }
     }
@@ -44,7 +43,7 @@ inline void Controller::store(uint32_t offset, T value) {
             break;
         }
         default: {
-            logger.logError(format("Unhandled Controller write at offset: %#x", offset));
+            logger.logError("Unhandled Controller write at offset: %#x", offset);
             break;
         }
     }

--- a/include/Controller.tcc
+++ b/include/Controller.tcc
@@ -16,7 +16,7 @@ inline T Controller::load(uint32_t offset) {
             return getControlRegister();
         }
         default: {
-            printError("Unhandled Controller read at offset: %#x", offset);
+            logger.logError(format("Unhandled Controller read at offset: %#x", offset));
             break;
         }
     }
@@ -44,7 +44,7 @@ inline void Controller::store(uint32_t offset, T value) {
             break;
         }
         default: {
-            printError("Unhandled Controller write at offset: %#x", offset);
+            logger.logError(format("Unhandled Controller write at offset: %#x", offset));
             break;
         }
     }

--- a/include/DMA.hpp
+++ b/include/DMA.hpp
@@ -6,6 +6,7 @@
 #include "GPU.hpp"
 #include <string>
 #include "CDROM.hpp"
+#include "Logger.hpp"
 
 enum Port {
     MDECin = 0,
@@ -133,6 +134,7 @@ union DMAInterrupt {
 // 1F8010F0h DPCR - DMA Control register
 // 1F8010F4h DICR - DMA Interrupt register
 class DMA {
+    Logger logger;
     std::unique_ptr<RAM> &ram;
     std::unique_ptr<GPU> &gpu;
     std::unique_ptr<CDROM> &cdrom;

--- a/include/DMA.hpp
+++ b/include/DMA.hpp
@@ -19,9 +19,6 @@ enum Port {
     None = 1337
 };
 
-Port portWithIndex(uint32_t index);
-std::string portDescription(Port port);
-
 // 1F8010F0h - DPCR - DMA Control Register (R/W)
 // 0-2   DMA0, MDECin  Priority      (0..7; 0=Highest, 7=Lowest)
 // 3     DMA0, MDECin  Master Enable (0=Disable, 1=Enable)
@@ -155,6 +152,9 @@ class DMA {
     void execute(Port port);
     void executeBlock(Port port, Channel& channel);
     void executeLinkedList(Port port, Channel& channel);
+
+    Port portWithIndex(uint32_t index);
+    std::string portDescription(Port port);
 public:
     DMA(std::unique_ptr<RAM> &ram, std::unique_ptr<GPU> &gpu, std::unique_ptr<CDROM> &cdrom);
     ~DMA();

--- a/include/DMA.tcc
+++ b/include/DMA.tcc
@@ -6,7 +6,7 @@ template <typename T>
 inline T DMA::load(uint32_t offset) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 4) {
-        printError("Unsupported DMA read with size: %d", sizeof(T));
+        logger.logError(format("Unsupported DMA read with size: %d", sizeof(T)));
     }
     uint32_t upper = (offset & 0x70) >> 4;
     uint32_t lower = (offset & 0xf);
@@ -31,7 +31,7 @@ inline T DMA::load(uint32_t offset) {
                     return channel.controlRegister();
                 }
                 default: {
-                    printError("Unhandled DMA read at offset: %#x", offset);
+                    logger.logError(format("Unhandled DMA read at offset: %#x", offset));
                     return 0;
                 }
             }
@@ -45,13 +45,13 @@ inline T DMA::load(uint32_t offset) {
                     return interruptRegister();
                 }
                 default: {
-                    printError("Unhandled DMA read at offset: %#x", offset);
+                    logger.logError(format("Unhandled DMA read at offset: %#x", offset));
                     return 0;
                 }
             }
         }
         default: {
-            printError("Unhandled DMA read at offset: %#x", offset);
+            logger.logError(format("Unhandled DMA read at offset: %#x", offset));
             return 0;
         }
     }
@@ -61,7 +61,7 @@ template <typename T>
 inline void DMA::store(uint32_t offset, T value) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 4) {
-        printError("Unsupported DMA write with size: %d", sizeof(T));
+        logger.logError(format("Unsupported DMA write with size: %d", sizeof(T)));
     }
     uint32_t upper = (offset & 0x70) >> 4;
     uint32_t lower = (offset & 0xf);
@@ -90,7 +90,7 @@ inline void DMA::store(uint32_t offset, T value) {
                     break;
                 }
                 default: {
-                    printError("Unhandled DMA write at offset: %#x", offset);
+                    logger.logError(format("Unhandled DMA write at offset: %#x", offset));
                     return;
                 }
             }
@@ -110,14 +110,14 @@ inline void DMA::store(uint32_t offset, T value) {
                     break;
                 }
                 default: {
-                    printError("Unhandled DMA write at offset: %#x", offset);
+                    logger.logError(format("Unhandled DMA write at offset: %#x", offset));
                     return;
                 }
             }
             break;
         }
         default: {
-            printError("Unhandled DMA write at offset: %#x", offset);
+            logger.logError(format("Unhandled DMA write at offset: %#x", offset));
             return;
         }
     }

--- a/include/DMA.tcc
+++ b/include/DMA.tcc
@@ -1,12 +1,11 @@
 #pragma once
 #include "DMA.hpp"
-#include "Output.hpp"
 
 template <typename T>
 inline T DMA::load(uint32_t offset) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 4) {
-        logger.logError(format("Unsupported DMA read with size: %d", sizeof(T)));
+        logger.logError("Unsupported DMA read with size: %d", sizeof(T));
     }
     uint32_t upper = (offset & 0x70) >> 4;
     uint32_t lower = (offset & 0xf);
@@ -31,7 +30,7 @@ inline T DMA::load(uint32_t offset) {
                     return channel.controlRegister();
                 }
                 default: {
-                    logger.logError(format("Unhandled DMA read at offset: %#x", offset));
+                    logger.logError("Unhandled DMA read at offset: %#x", offset);
                     return 0;
                 }
             }
@@ -45,13 +44,13 @@ inline T DMA::load(uint32_t offset) {
                     return interruptRegister();
                 }
                 default: {
-                    logger.logError(format("Unhandled DMA read at offset: %#x", offset));
+                    logger.logError("Unhandled DMA read at offset: %#x", offset);
                     return 0;
                 }
             }
         }
         default: {
-            logger.logError(format("Unhandled DMA read at offset: %#x", offset));
+            logger.logError("Unhandled DMA read at offset: %#x", offset);
             return 0;
         }
     }
@@ -61,7 +60,7 @@ template <typename T>
 inline void DMA::store(uint32_t offset, T value) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 4) {
-        logger.logError(format("Unsupported DMA write with size: %d", sizeof(T)));
+        logger.logError("Unsupported DMA write with size: %d", sizeof(T));
     }
     uint32_t upper = (offset & 0x70) >> 4;
     uint32_t lower = (offset & 0xf);
@@ -90,7 +89,7 @@ inline void DMA::store(uint32_t offset, T value) {
                     break;
                 }
                 default: {
-                    logger.logError(format("Unhandled DMA write at offset: %#x", offset));
+                    logger.logError("Unhandled DMA write at offset: %#x", offset);
                     return;
                 }
             }
@@ -110,14 +109,14 @@ inline void DMA::store(uint32_t offset, T value) {
                     break;
                 }
                 default: {
-                    logger.logError(format("Unhandled DMA write at offset: %#x", offset));
+                    logger.logError("Unhandled DMA write at offset: %#x", offset);
                     return;
                 }
             }
             break;
         }
         default: {
-            logger.logError(format("Unhandled DMA write at offset: %#x", offset));
+            logger.logError("Unhandled DMA write at offset: %#x", offset);
             return;
         }
     }

--- a/include/Emulator.hpp
+++ b/include/Emulator.hpp
@@ -18,8 +18,10 @@
 #include <vector>
 #include "Controller.hpp"
 #include <string>
+#include "Logger.hpp"
 
 class Emulator {
+    Logger logger;
     std::unique_ptr<Window> mainWindow;
     std::unique_ptr<Window> debugWindow;
 

--- a/include/EmulatorRunner.hpp
+++ b/include/EmulatorRunner.hpp
@@ -2,6 +2,7 @@
 #include <memory>
 #include <string>
 #include "Emulator.hpp"
+#include "Logger.hpp"
 
 // XXXX_NNN.NN (Boot-Executable) (filename specified in SYSTEM.CNF)
 // FILENAME.EXE (General-Purpose Executable)
@@ -33,6 +34,7 @@ const uint32_t TEST_HEADER_SIZE = 2048;
 class EmulatorRunner {
     static EmulatorRunner* instance;
 
+    Logger logger;
     Emulator *emulator;
     bool runTests;
     std::string exeFile;

--- a/include/GPU.hpp
+++ b/include/GPU.hpp
@@ -6,6 +6,7 @@
 #include "Renderer.hpp"
 #include "GPUImageBuffer.hpp"
 #include "Window.hpp"
+#include "Logger.hpp"
 
 enum TexturePageColors {
     T4Bit = 0,
@@ -78,6 +79,7 @@ enum GP0Mode {
 31    Drawing even/odd lines in interlace mode (0=Even or Vblank, 1=Odd)
 */
 class GPU {
+    Logger logger;
     uint8_t texturePageBaseX;
     uint8_t texturePageBaseY;
     uint8_t semiTransparency;
@@ -250,7 +252,7 @@ GP1(07h) - Vertical Display range (on Screen)
 
     void executeGp1(uint32_t value);
 public:
-    GPU(std::unique_ptr<Window> &mainWindow);
+    GPU(LogLevel logLevel, std::unique_ptr<Window> &mainWindow);
     ~GPU();
     template <typename T>
     inline T load(uint32_t offset) const;

--- a/include/GPU.hpp
+++ b/include/GPU.hpp
@@ -251,6 +251,8 @@ GP1(07h) - Vertical Display range (on Screen)
     void shadedLine(uint numberOfPoints, bool opaque);
 
     void executeGp1(uint32_t value);
+    TexturePageColors texturePageColorsWithValue(uint32_t value) const;
+    uint8_t horizontalResolutionFromValues(uint8_t value1, uint8_t value2) const;
 public:
     GPU(LogLevel logLevel, std::unique_ptr<Window> &mainWindow);
     ~GPU();
@@ -265,5 +267,3 @@ public:
     Dimensions getResolution();
     Point getDisplayAreaStart();
 };
-
-TexturePageColors texturePageColorsWithValue(uint32_t value);

--- a/include/GPU.tcc
+++ b/include/GPU.tcc
@@ -6,7 +6,7 @@ template <typename T>
 inline T GPU::load(uint32_t offset) const {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 4) {
-        printError("Unsupported GPU read with size: %d", sizeof(T));
+        logger.logError(format("Unsupported GPU read with size: %d", sizeof(T)));
     }
     switch (offset) {
         case 0: {
@@ -16,7 +16,7 @@ inline T GPU::load(uint32_t offset) const {
             return statusRegister();
         }
         default: {
-            printError("Unhandled GPU read at offset: %#x", offset);
+            logger.logError(format("Unhandled GPU read at offset: %#x", offset));
             return 0;
         }
     }
@@ -26,7 +26,7 @@ template <typename T>
 inline void GPU::store(uint32_t offset, T value) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 4) {
-        printError("Unsupported GPU write with size: %d", sizeof(T));
+        logger.logError(format("Unsupported GPU write with size: %d", sizeof(T)));
     }
     switch (offset) {
         case 0: {
@@ -38,7 +38,7 @@ inline void GPU::store(uint32_t offset, T value) {
             break;
         }
         default: {
-            printError("Unhandled GPU write at offset: %#x", offset);
+            logger.logError(format("Unhandled GPU write at offset: %#x", offset));
             return;
         }
     }

--- a/include/GPU.tcc
+++ b/include/GPU.tcc
@@ -1,12 +1,11 @@
 #pragma once
 #include "GPU.hpp"
-#include "Output.hpp"
 
 template <typename T>
 inline T GPU::load(uint32_t offset) const {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 4) {
-        logger.logError(format("Unsupported GPU read with size: %d", sizeof(T)));
+        logger.logError("Unsupported GPU read with size: %d", sizeof(T));
     }
     switch (offset) {
         case 0: {
@@ -16,7 +15,7 @@ inline T GPU::load(uint32_t offset) const {
             return statusRegister();
         }
         default: {
-            logger.logError(format("Unhandled GPU read at offset: %#x", offset));
+            logger.logError("Unhandled GPU read at offset: %#x", offset);
             return 0;
         }
     }
@@ -26,7 +25,7 @@ template <typename T>
 inline void GPU::store(uint32_t offset, T value) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (sizeof(T) != 4) {
-        logger.logError(format("Unsupported GPU write with size: %d", sizeof(T)));
+        logger.logError("Unsupported GPU write with size: %d", sizeof(T));
     }
     switch (offset) {
         case 0: {
@@ -38,7 +37,7 @@ inline void GPU::store(uint32_t offset, T value) {
             break;
         }
         default: {
-            logger.logError(format("Unhandled GPU write at offset: %#x", offset));
+            logger.logError("Unhandled GPU write at offset: %#x", offset);
             return;
         }
     }

--- a/include/GPUInstructionBuffer.hpp
+++ b/include/GPUInstructionBuffer.hpp
@@ -1,9 +1,11 @@
 #pragma once
 #include <cstdint>
+#include "Logger.hpp"
 
 const uint32_t GPU_INSTRUCTION_BUFFER_SIZE = 12;
 
 class GPUInstructionBuffer {
+    Logger logger;
     uint32_t buffer[GPU_INSTRUCTION_BUFFER_SIZE];
     uint8_t length;
 public:

--- a/include/Helpers.hpp
+++ b/include/Helpers.hpp
@@ -2,5 +2,6 @@
 #include <string>
 #include <cstdint>
 
+void readBinary(const std::string& path, uint8_t *data, uint32_t atOrigin);
 void readBinary(const std::string& path, uint8_t *data);
 uint8_t decimalFromBCDEncodedInt(uint8_t bcdEncoded);

--- a/include/Interconnect.hpp
+++ b/include/Interconnect.hpp
@@ -13,6 +13,7 @@
 #include "Expansion1.hpp"
 #include "Timer.hpp"
 #include "Controller.hpp"
+#include "Logger.hpp"
 
 const Range ramRange = Range(0x00000000, RAM_SIZE);
 const Range scratchpadRange = Range(0x1f800000, SCRATCHPAD_SIZE);
@@ -47,6 +48,7 @@ KUSEG     KSEG0     KSEG1
 See IOMap.md for I/O register mapping
 */
 class Interconnect {
+    Logger logger;
     std::unique_ptr<COP0> &cop0;
     std::unique_ptr<BIOS> &bios;
     std::unique_ptr<RAM> &ram;
@@ -62,7 +64,7 @@ class Interconnect {
     std::unique_ptr<Controller> &controller;
     uint32_t maskRegion(uint32_t address) const;
 public:
-    Interconnect(std::unique_ptr<COP0> &cop0, std::unique_ptr<BIOS> &bios, std::unique_ptr<RAM> &ram, std::unique_ptr<GPU> &gpu, std::unique_ptr<DMA> &dma, std::unique_ptr<Scratchpad> &scratchpad, std::unique_ptr<CDROM> &cdrom, std::unique_ptr<InterruptController> &interruptController, std::unique_ptr<Expansion1> &expansion1, std::unique_ptr<Timer0> &timer0, std::unique_ptr<Timer1> &timer1, std::unique_ptr<Timer2> &timer2, std::unique_ptr<Controller> &controller);
+    Interconnect(LogLevel logLevel, std::unique_ptr<COP0> &cop0, std::unique_ptr<BIOS> &bios, std::unique_ptr<RAM> &ram, std::unique_ptr<GPU> &gpu, std::unique_ptr<DMA> &dma, std::unique_ptr<Scratchpad> &scratchpad, std::unique_ptr<CDROM> &cdrom, std::unique_ptr<InterruptController> &interruptController, std::unique_ptr<Expansion1> &expansion1, std::unique_ptr<Timer0> &timer0, std::unique_ptr<Timer1> &timer1, std::unique_ptr<Timer2> &timer2, std::unique_ptr<Controller> &controller);
     ~Interconnect();
 
     template <typename T>

--- a/include/Interconnect.tcc
+++ b/include/Interconnect.tcc
@@ -56,7 +56,7 @@ inline T Interconnect::load(uint32_t address) const {
     }
     offset = soundProcessingUnitRange.contains(absoluteAddress);
     if (offset) {
-        printMessage("Unhandled Sound Processing Unit read at offset: %#x", *offset);
+        logger.logMessage(format("Unhandled Sound Processing Unit read at offset: %#x", *offset));
         return 0;
     }
     offset = scratchpadRange.contains(absoluteAddress);
@@ -71,7 +71,7 @@ inline T Interconnect::load(uint32_t address) const {
     if (offset) {
         return controller->load<T>(*offset);
     }
-    printWarning("Unhandled read at: %#x", address);
+    logger.logWarning(format("Unhandled read at: %#x", address));
     Debugger *debugger = Debugger::getInstance();
     if (debugger->isAttached()) {
         return 0;
@@ -83,7 +83,7 @@ template <typename T>
 inline void Interconnect::store(uint32_t address, T value) const {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (address % sizeof(T) != 0) {
-        printError("Unaligned memory store");
+        logger.logError("Unaligned memory store");
         exit(1);
     }
     uint32_t absoluteAddress = maskRegion(address);
@@ -105,7 +105,7 @@ inline void Interconnect::store(uint32_t address, T value) const {
                 break;
             }
             default: {
-                printWarning("Unhandled Memory Control write at offset: %#x", *offset);
+                logger.logWarning(format("Unhandled Memory Control write at offset: %#x", *offset));
                 break;
             }
         }
@@ -113,12 +113,12 @@ inline void Interconnect::store(uint32_t address, T value) const {
     }
     offset = ramSizeRange.contains(absoluteAddress);
     if (offset) {
-        printWarning("Unhandled RAM Control write at offset: %#x", *offset);
+        logger.logWarning(format("Unhandled RAM Control write at offset: %#x", *offset));
         return;
     }
     offset = cacheControlRange.contains(absoluteAddress);
     if (offset) {
-        printWarning("Unhandled Cache Control write at offset: %#x", *offset);
+        logger.logWarning(format("Unhandled Cache Control write at offset: %#x", *offset));
         return;
     }
     offset = ramRange.contains(absoluteAddress);
@@ -161,12 +161,12 @@ inline void Interconnect::store(uint32_t address, T value) const {
     }
     offset = soundProcessingUnitRange.contains(absoluteAddress);
     if (offset) {
-        printMessage("Unhandled Sound Processing Unit write at offset: %#x", *offset);
+        logger.logMessage(format("Unhandled Sound Processing Unit write at offset: %#x", *offset));
         return;
     }
     offset = expansion2Range.contains(absoluteAddress);
     if (offset) {
-        printWarning("Unhandled Expansion 2 write at offset: %#x", *offset);
+        logger.logWarning(format("Unhandled Expansion 2 write at offset: %#x", *offset));
         return;
     }
     offset = scratchpadRange.contains(absoluteAddress);
@@ -184,5 +184,5 @@ inline void Interconnect::store(uint32_t address, T value) const {
         controller->store<T>(*offset, value);
         return;
     }
-    printError("Unhandled write at: %#x", address);
+    logger.logError(format("Unhandled write at: %#x", address));
 }

--- a/include/Interconnect.tcc
+++ b/include/Interconnect.tcc
@@ -1,6 +1,5 @@
 #pragma once
 #include "Interconnect.hpp"
-#include "Output.hpp"
 #include "RAM.tcc"
 #include "BIOS.tcc"
 #include "GPU.tcc"
@@ -56,7 +55,7 @@ inline T Interconnect::load(uint32_t address) const {
     }
     offset = soundProcessingUnitRange.contains(absoluteAddress);
     if (offset) {
-        logger.logMessage(format("Unhandled Sound Processing Unit read at offset: %#x", *offset));
+        logger.logMessage("Unhandled Sound Processing Unit read at offset: %#x", *offset);
         return 0;
     }
     offset = scratchpadRange.contains(absoluteAddress);
@@ -71,7 +70,7 @@ inline T Interconnect::load(uint32_t address) const {
     if (offset) {
         return controller->load<T>(*offset);
     }
-    logger.logWarning(format("Unhandled read at: %#x", address));
+    logger.logWarning("Unhandled read at: %#x", address);
     Debugger *debugger = Debugger::getInstance();
     if (debugger->isAttached()) {
         return 0;
@@ -105,7 +104,7 @@ inline void Interconnect::store(uint32_t address, T value) const {
                 break;
             }
             default: {
-                logger.logWarning(format("Unhandled Memory Control write at offset: %#x", *offset));
+                logger.logWarning("Unhandled Memory Control write at offset: %#x", *offset);
                 break;
             }
         }
@@ -113,12 +112,12 @@ inline void Interconnect::store(uint32_t address, T value) const {
     }
     offset = ramSizeRange.contains(absoluteAddress);
     if (offset) {
-        logger.logWarning(format("Unhandled RAM Control write at offset: %#x", *offset));
+        logger.logWarning("Unhandled RAM Control write at offset: %#x", *offset);
         return;
     }
     offset = cacheControlRange.contains(absoluteAddress);
     if (offset) {
-        logger.logWarning(format("Unhandled Cache Control write at offset: %#x", *offset));
+        logger.logWarning("Unhandled Cache Control write at offset: %#x", *offset);
         return;
     }
     offset = ramRange.contains(absoluteAddress);
@@ -161,12 +160,12 @@ inline void Interconnect::store(uint32_t address, T value) const {
     }
     offset = soundProcessingUnitRange.contains(absoluteAddress);
     if (offset) {
-        logger.logMessage(format("Unhandled Sound Processing Unit write at offset: %#x", *offset));
+        logger.logMessage("Unhandled Sound Processing Unit write at offset: %#x", *offset);
         return;
     }
     offset = expansion2Range.contains(absoluteAddress);
     if (offset) {
-        logger.logWarning(format("Unhandled Expansion 2 write at offset: %#x", *offset));
+        logger.logWarning("Unhandled Expansion 2 write at offset: %#x", *offset);
         return;
     }
     offset = scratchpadRange.contains(absoluteAddress);
@@ -184,5 +183,5 @@ inline void Interconnect::store(uint32_t address, T value) const {
         controller->store<T>(*offset, value);
         return;
     }
-    logger.logError(format("Unhandled write at: %#x", address));
+    logger.logError("Unhandled write at: %#x", address);
 }

--- a/include/InterruptController.hpp
+++ b/include/InterruptController.hpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <memory>
 #include "COP0.hpp"
+#include "Logger.hpp"
 
 enum InterruptRequestNumber : uint16_t {
     VBLANK = 0,
@@ -57,6 +58,7 @@ Mask: Read/Write I_MASK (0=Disabled, 1=Enabled)
   16-31 Garbage
 */
 class InterruptController {
+    Logger logger;
     std::unique_ptr<COP0> &cop0;
 
     IRQ status;

--- a/include/InterruptController.tcc
+++ b/include/InterruptController.tcc
@@ -12,7 +12,7 @@ inline T InterruptController::load(uint32_t offset) const {
             return mask.value;
         }
         default: {
-            printError("Unhandled Interrupt Request Control read at offset: %#x", offset);
+            logger.logError(format("Unhandled Interrupt Request Control read at offset: %#x", offset));
             return 0;
         }
     }
@@ -31,7 +31,7 @@ inline void InterruptController::store(uint32_t offset, T value) {
             return;
         }
         default: {
-            printError("Unhandled Interrupt Request Control write at offset: %#x", offset);
+            logger.logError(format("Unhandled Interrupt Request Control write at offset: %#x", offset));
             return;
         }
     }

--- a/include/InterruptController.tcc
+++ b/include/InterruptController.tcc
@@ -1,5 +1,4 @@
 #include "InterruptController.hpp"
-#include "Output.hpp"
 
 template <typename T>
 inline T InterruptController::load(uint32_t offset) const {
@@ -12,7 +11,7 @@ inline T InterruptController::load(uint32_t offset) const {
             return mask.value;
         }
         default: {
-            logger.logError(format("Unhandled Interrupt Request Control read at offset: %#x", offset));
+            logger.logError("Unhandled Interrupt Request Control read at offset: %#x", offset);
             return 0;
         }
     }
@@ -31,7 +30,7 @@ inline void InterruptController::store(uint32_t offset, T value) {
             return;
         }
         default: {
-            logger.logError(format("Unhandled Interrupt Request Control write at offset: %#x", offset));
+            logger.logError("Unhandled Interrupt Request Control write at offset: %#x", offset);
             return;
         }
     }

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -18,7 +18,6 @@ class Logger {
 public:
     Logger(LogLevel level);
     Logger(LogLevel level, bool shouldTrace);
-    void setupTraceFile();
     void logDebug(std::string message) const;
     void logMessage(std::string message) const;
     void logWarning(std::string message) const;

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -1,22 +1,27 @@
 #pragma once
 #include <sstream>
 #include <string>
+#include <limits>
+
+enum LogLevel : uint8_t {
+    NoLog = 0,
+    Warning = 1,
+    Message = 2,
+};
+
+LogLevel logLevelWithValue(std::string value);
 
 class Logger {
-    static Logger* instance;
-
+    LogLevel level;
     bool shouldTrace;
-    bool shouldLogVerbose;
-    std::stringstream stream;
-    uint16_t bufferSize;
-    void traceMessage(std::string message);
-    Logger();
+    void traceMessage(std::string message) const;
 public:
-    static Logger* getInstance();
-    void configure(bool enableTrace, bool enableVerbose);
+    Logger(LogLevel level);
+    Logger(LogLevel level, bool shouldTrace);
     void setupTraceFile();
-    void logMessage(std::string message);
-    void logWarning(std::string message);
-    void logError(std::string message);
-    void flush();
+    void logDebug(std::string message) const;
+    void logMessage(std::string message) const;
+    void logWarning(std::string message) const;
+    void logError(std::string message) const;
+    void flush() const;
 };

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -18,9 +18,9 @@ class Logger {
 public:
     Logger(LogLevel level);
     Logger(LogLevel level, bool shouldTrace);
-    void logDebug(std::string message) const;
-    void logMessage(std::string message) const;
-    void logWarning(std::string message) const;
-    void logError(std::string message) const;
+    void logDebug(const char *fmt, ...) const;
+    void logMessage(const char *fmt, ...) const;
+    void logWarning(const char *fmt, ...) const;
+    void logError(const char *fmt, ...) const;
     void flush() const;
 };

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -13,11 +13,13 @@ LogLevel logLevelWithValue(std::string value);
 
 class Logger {
     LogLevel level;
+    std::string prefix;
     bool shouldTrace;
     void traceMessage(std::string message) const;
 public:
     Logger(LogLevel level);
-    Logger(LogLevel level, bool shouldTrace);
+    Logger(LogLevel level, std::string prefix);
+    Logger(LogLevel level, std::string prefix, bool shouldTrace);
     void logDebug(const char *fmt, ...) const;
     void logMessage(const char *fmt, ...) const;
     void logWarning(const char *fmt, ...) const;

--- a/include/Output.hpp
+++ b/include/Output.hpp
@@ -2,6 +2,3 @@
 #include <string>
 
 std::string format(const char *fmt, ...);
-void printMessage(const char *fmt, ...);
-void printWarning(const char *fmt, ...);
-void printError(const char *fmt, ...);

--- a/include/Output.hpp
+++ b/include/Output.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstdarg>
 #include <string>
 
+std::string format(const char *fmt, va_list args);
 std::string format(const char *fmt, ...);

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -9,10 +9,12 @@
 #include "GPUImageBuffer.hpp"
 #include "Texture.hpp"
 #include "Window.hpp"
+#include "Logger.hpp"
 
 class GPU;
 
 class Renderer {
+    Logger logger;
     GLuint offsetUniform;
 
     std::unique_ptr<RendererProgram> program;

--- a/include/RendererDebugger.hpp
+++ b/include/RendererDebugger.hpp
@@ -1,3 +1,42 @@
 #pragma once
+#include <string>
+#include "Logger.hpp"
 
-void checkForOpenGLErrors();
+enum DebugSource : uint32_t {
+    API = 0x8246,
+    WindowSystem = 0x8247,
+    ShaderCompiler = 0x8248,
+    ThirdParty = 0x8249,
+    Application = 0x824A,
+    OtherSource = 0x824B
+};
+
+enum DebugType : uint32_t {
+    Error = 0x824C,
+    DeprecatedBehaviour = 0x824D,
+    UndefinedBehaviour = 0x824E,
+    Portability = 0x824F,
+    Performance = 0x8250,
+    OtherType = 0x8251
+};
+
+enum DebugSeverity : uint32_t {
+    High = 0x9146,
+    Medium = 0x9147,
+    Low = 0x9148,
+    Notification = 0x826B
+};
+
+class RendererDebugger {
+    static RendererDebugger* instance;
+    Logger logger;
+
+    std::string debugSourceDescription(DebugSource source) const;
+    std::string debugTypeDescription(DebugType type) const;
+    std::string debugSeverityDescription(DebugSeverity severity) const;
+    RendererDebugger(LogLevel logLevel);
+public:
+    static RendererDebugger* getInstance();
+
+    void checkForOpenGLErrors() const;
+};

--- a/include/Texture.hpp
+++ b/include/Texture.hpp
@@ -3,8 +3,10 @@
 #include <cstdint>
 #include <memory>
 #include "GPUImageBuffer.hpp"
+#include "Logger.hpp"
 
 class Texture {
+    Logger logger;
     GLuint object;
     GLsizei width;
     GLsizei height;

--- a/include/Timer.hpp
+++ b/include/Timer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include "Logger.hpp"
 
 enum Timer0SyncMode {
     PauseDuringHblank = 0,
@@ -158,6 +159,7 @@ union TimerCounterTarget {
 };
 
 class Timer {
+    Logger logger;
 protected:
     uint8_t identity;
     TimerCounterValue counterValue;

--- a/include/Timer.tcc
+++ b/include/Timer.tcc
@@ -16,7 +16,7 @@ inline T Timer::load(uint32_t offset) {
             return counterTargetRegister();
         }
         default: {
-            printError("Unhandled Timer load at offset: %#x", offset);
+            logger.logError(format("Unhandled Timer load at offset: %#x", offset));
             return 0;
         }
     }
@@ -40,7 +40,7 @@ inline void Timer::store(uint32_t offset, T value) {
             return;
         }
         default: {
-            printError("Unhandled Timer load at offset: %#x", offset);
+            logger.logError(format("Unhandled Timer load at offset: %#x", offset));
             return;
         }
     }

--- a/include/Timer.tcc
+++ b/include/Timer.tcc
@@ -16,7 +16,7 @@ inline T Timer::load(uint32_t offset) {
             return counterTargetRegister();
         }
         default: {
-            logger.logError(format("Unhandled Timer load at offset: %#x", offset));
+            logger.logError("Unhandled Timer load at offset: %#x", offset);
             return 0;
         }
     }
@@ -40,7 +40,7 @@ inline void Timer::store(uint32_t offset, T value) {
             return;
         }
         default: {
-            logger.logError(format("Unhandled Timer load at offset: %#x", offset));
+            logger.logError("Unhandled Timer load at offset: %#x", offset);
             return;
         }
     }

--- a/include/Window.hpp
+++ b/include/Window.hpp
@@ -3,8 +3,10 @@
 #include <string>
 #include <cstdint>
 #include <Vertex.hpp>
+#include "Logger.hpp"
 
 class Window {
+    Logger logger;
     bool mainWindow;
     std::string title;
     uint32_t width;

--- a/src/BIOS.cpp
+++ b/src/BIOS.cpp
@@ -1,7 +1,5 @@
 #include "BIOS.hpp"
-#include "Output.hpp"
 #include "Helpers.hpp"
-#include "Output.hpp"
 #include <sstream>
 
 const uint32_t BIOS_A_FUNCTIONS_STEP = 0xA0;
@@ -24,7 +22,7 @@ void BIOS::loadBin(const string& path) {
 
 std::string BIOS::formatBIOSFunction(std::string function, uint argc, std::array<uint32_t, 4> subroutineArguments) {
     if (argc > 4) {
-        logger.logError(format("BIOS formatting incorrect function with argc: %d", argc));
+        logger.logError("BIOS formatting incorrect function with argc: %d", argc);
     }
 
     stringstream ss;
@@ -1045,5 +1043,5 @@ optional<string> BIOS::checkFunctions(uint32_t programCounter, uint32_t r9, arra
     if (functionCallLogIsRFE) {
         return result;
     }
-    logger.logMessage(format("  BIOS: %s", functionCallLog.c_str()));
+    logger.logMessage("  BIOS: %s", functionCallLog.c_str());
 }

--- a/src/BIOS.cpp
+++ b/src/BIOS.cpp
@@ -8,7 +8,7 @@ const uint32_t BIOS_C_FUNCTIONS_STEP = 0xC0;
 
 using namespace std;
 
-BIOS::BIOS(LogLevel logLevel) : data(), logger(logLevel) {
+BIOS::BIOS(LogLevel logLevel) : data(), logger(logLevel, "  BIOS: ") {
 
 }
 
@@ -1043,5 +1043,5 @@ optional<string> BIOS::checkFunctions(uint32_t programCounter, uint32_t r9, arra
     if (functionCallLogIsRFE) {
         return result;
     }
-    logger.logMessage("  BIOS: %s", functionCallLog.c_str());
+    logger.logMessage(functionCallLog.c_str());
 }

--- a/src/CDImage.cpp
+++ b/src/CDImage.cpp
@@ -1,5 +1,4 @@
 #include "CDImage.hpp"
-#include "Output.hpp"
 
 using namespace std;
 

--- a/src/CDImage.cpp
+++ b/src/CDImage.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-CDImage::CDImage() : file() {
+CDImage::CDImage() : file(), logger(LogLevel::NoLog) {
 }
 
 CDImage::~CDImage() {
@@ -13,7 +13,7 @@ CDImage::~CDImage() {
 void CDImage::open(string filePath) {
     file.open(filePath, ios::binary);
     if (!file.is_open()) {
-        printError("Unable to load CD-ROM image file");
+        logger.logError("Unable to load CD-ROM image file");
     }
 }
 

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -1,6 +1,7 @@
 #include "CDROM.hpp"
 #include "Output.hpp"
 #include "Helpers.hpp"
+#include "ConfigurationManager.hpp"
 
 using namespace std;
 
@@ -16,7 +17,7 @@ should be: SystemClock*930h/4/44100Hz for Single Speed (and half as much for Dou
 const uint32_t SystemClocksPerCDROMInt1SingleSpeed=2352;
 const uint32_t SystemClocksPerCDROMInt1DoubleSpeed=2352/2;
 
-CDROM::CDROM(unique_ptr<InterruptController> &interruptController, bool logActivity) : interruptController(interruptController), image(), logActivity(logActivity), status(), interrupt(), statusCode(), mode(), parameters(), response(), interruptQueue(), seekSector(), readSector(), counter(), currentSector(), readBuffer(), readBufferIndex() {
+CDROM::CDROM(LogLevel logLevel, unique_ptr<InterruptController> &interruptController) : logger(logLevel), interruptController(interruptController), image(), status(), interrupt(), statusCode(), mode(), parameters(), response(), interruptQueue(), seekSector(), readSector(), counter(), currentSector(), readBuffer(), readBufferIndex() {
 
 }
 
@@ -42,17 +43,17 @@ void CDROM::step() {
 }
 
 void CDROM::setStatusRegister(uint8_t value) {
-    logMessage(format("STATUS [W]: %#x", value));
+    logger.logMessage(format("STATUS [W]: %#x", value));
     status.index = value & 0x3;
 }
 
 void CDROM::setInterruptRegister(uint8_t value) {
-    logMessage(format("INTE [W]: %#x", value));
+    logger.logMessage(format("INTE [W]: %#x", value));
     interrupt.enable = value;
 }
 
 void CDROM::setInterruptFlagRegister(uint8_t value) {
-    logMessage(format("INTF [W]: %#x", value));
+    logger.logMessage(format("INTF [W]: %#x", value));
     if (value & 0x40) {
         clearParameters();
         updateStatusRegister();
@@ -63,7 +64,7 @@ void CDROM::setInterruptFlagRegister(uint8_t value) {
 }
 
 void CDROM::setRequestRegister(uint8_t value) {
-    logMessage(format("REQ [W]: %#x", value));
+    logger.logMessage(format("REQ [W]: %#x", value));
     if (value & 0x80) {
         readBuffer.clear();
         if (isReadBufferEmpty()) {
@@ -123,7 +124,7 @@ void CDROM::execute(uint8_t value) {
             break;
         }
         default: {
-            printError("Unhandled CDROM operation value: %#x", value);
+            logger.logError(format("Unhandled CDROM operation value: %#x", value));
         }
     }
     clearParameters();
@@ -131,7 +132,7 @@ void CDROM::execute(uint8_t value) {
 }
 
 uint8_t CDROM::getStatusRegister() const {
-    logMessage(format("STATUS [R]: %#x", status._value));
+    logger.logMessage(format("STATUS [R]: %#x", status._value));
     return status._value;
 }
 
@@ -140,7 +141,7 @@ uint8_t CDROM::getInterruptFlagRegister() const {
     if (!interruptQueue.empty()) {
         flags |= interruptQueue.front() & 0x7;
     }
-    logMessage(format("INTF [R]: %#x", flags));
+    logger.logMessage(format("INTF [R]: %#x", flags));
     return flags;
 }
 
@@ -151,12 +152,12 @@ uint8_t CDROM::getReponse() {
         response.pop();
         updateStatusRegister();
     }
-    logMessage(format("RESPONSE [R]: %#x", value));
+    logger.logMessage(format("RESPONSE [R]: %#x", value));
     return value;
 }
 
 uint8_t CDROM::getInterruptRegister() const {
-    logMessage(format("INTE [R]: %#x", interrupt.enable));
+    logger.logMessage(format("INTE [R]: %#x", interrupt.enable));
     return interrupt.enable;
 }
 
@@ -177,7 +178,7 @@ void CDROM::clearResponse() {
 
 void CDROM::pushParameter(uint8_t value) {
     if (parameters.size() >= 16) {
-        printError("Parameter FIFO full");
+        logger.logError("Parameter FIFO full");
     }
     parameters.push(value);
     updateStatusRegister();
@@ -185,7 +186,7 @@ void CDROM::pushParameter(uint8_t value) {
 
 void CDROM::pushResponse(uint8_t value) {
     if (response.size() >= 16) {
-        printError("Response FIFO full");
+        logger.logError("Response FIFO full");
     }
     response.push(value);
     updateStatusRegister();
@@ -280,17 +281,17 @@ void CDROM::operationTest() {
             break;
         }
         default: {
-            printError("Unhandled CDROM operation test with subfunction: %#x", subfunction);
+            logger.logError(format("Unhandled CDROM operation test with subfunction: %#x", subfunction));
         }
     }
-    logMessage(format("CMD Test [%#x]", subfunction));
+    logger.logMessage(format("CMD Test [%#x]", subfunction));
 }
 
 /*
 Getstat - Command 01h --> INT3(stat)
 */
 void CDROM::operationGetstat() {
-    logMessage("CMD Getstat");
+    logger.logMessage("CMD Getstat");
     pushResponse(statusCode._value);
     interruptQueue.push(INT3);
 }
@@ -323,7 +324,7 @@ void CDROM::operationGetID() {
     pushResponse('A');
     interruptQueue.push(INT2);
 
-    logMessage("CMD GetID");
+    logger.logMessage("CMD GetID");
 }
 
 /*
@@ -339,7 +340,7 @@ void CDROM::operationSetloc() {
     pushResponse(statusCode._value);
     interruptQueue.push(INT3);
 
-    logMessage(format("CMD Setloc(%d, %d, %d)", minute, second, sector));
+    logger.logMessage(format("CMD Setloc(%d, %d, %d)", minute, second, sector));
 }
 
 /*
@@ -356,7 +357,7 @@ void CDROM::operationSeekL() {
     pushResponse(statusCode._value);
     interruptQueue.push(INT2);
 
-    logMessage("CMD SeekL");
+    logger.logMessage("CMD SeekL");
 }
 
 /*
@@ -369,7 +370,7 @@ void CDROM::operationSetmode() {
     pushResponse(statusCode._value);
     interruptQueue.push(INT3);
 
-    logMessage("CMD Setmode");
+    logger.logMessage("CMD Setmode");
 }
 
 /*
@@ -383,7 +384,7 @@ void CDROM::operationReadN() {
     pushResponse(statusCode._value);
     interruptQueue.push(INT3);
 
-    logMessage("CMD ReadN");
+    logger.logMessage("CMD ReadN");
 }
 
 /*
@@ -397,7 +398,7 @@ void CDROM::operationPause() {
     pushResponse(statusCode._value);
     interruptQueue.push(INT2);
 
-    logMessage("CMD Pause");
+    logger.logMessage("CMD Pause");
 }
 
 /*
@@ -415,14 +416,7 @@ void CDROM::operationInit() {
     pushResponse(statusCode._value);
     interruptQueue.push(INT2);
 
-    logMessage("CMD Init");
-}
-
-void CDROM::logMessage(std::string message) const {
-    if (!logActivity) {
-        return;
-    }
-    printWarning("  CD-ROM: %s", message.c_str());
+    logger.logMessage("CMD Init");
 }
 
 void CDROM::loadCDROMImageFile(string filePath) {

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -1,5 +1,4 @@
 #include "CDROM.hpp"
-#include "Output.hpp"
 #include "Helpers.hpp"
 #include "ConfigurationManager.hpp"
 
@@ -43,17 +42,17 @@ void CDROM::step() {
 }
 
 void CDROM::setStatusRegister(uint8_t value) {
-    logger.logMessage(format("STATUS [W]: %#x", value));
+    logger.logMessage("STATUS [W]: %#x", value);
     status.index = value & 0x3;
 }
 
 void CDROM::setInterruptRegister(uint8_t value) {
-    logger.logMessage(format("INTE [W]: %#x", value));
+    logger.logMessage("INTE [W]: %#x", value);
     interrupt.enable = value;
 }
 
 void CDROM::setInterruptFlagRegister(uint8_t value) {
-    logger.logMessage(format("INTF [W]: %#x", value));
+    logger.logMessage("INTF [W]: %#x", value);
     if (value & 0x40) {
         clearParameters();
         updateStatusRegister();
@@ -64,7 +63,7 @@ void CDROM::setInterruptFlagRegister(uint8_t value) {
 }
 
 void CDROM::setRequestRegister(uint8_t value) {
-    logger.logMessage(format("REQ [W]: %#x", value));
+    logger.logMessage("REQ [W]: %#x", value);
     if (value & 0x80) {
         readBuffer.clear();
         if (isReadBufferEmpty()) {
@@ -124,7 +123,7 @@ void CDROM::execute(uint8_t value) {
             break;
         }
         default: {
-            logger.logError(format("Unhandled CDROM operation value: %#x", value));
+            logger.logError("Unhandled CDROM operation value: %#x", value);
         }
     }
     clearParameters();
@@ -132,7 +131,7 @@ void CDROM::execute(uint8_t value) {
 }
 
 uint8_t CDROM::getStatusRegister() const {
-    logger.logMessage(format("STATUS [R]: %#x", status._value));
+    logger.logMessage("STATUS [R]: %#x", status._value);
     return status._value;
 }
 
@@ -141,7 +140,7 @@ uint8_t CDROM::getInterruptFlagRegister() const {
     if (!interruptQueue.empty()) {
         flags |= interruptQueue.front() & 0x7;
     }
-    logger.logMessage(format("INTF [R]: %#x", flags));
+    logger.logMessage("INTF [R]: %#x", flags);
     return flags;
 }
 
@@ -152,12 +151,12 @@ uint8_t CDROM::getReponse() {
         response.pop();
         updateStatusRegister();
     }
-    logger.logMessage(format("RESPONSE [R]: %#x", value));
+    logger.logMessage("RESPONSE [R]: %#x", value);
     return value;
 }
 
 uint8_t CDROM::getInterruptRegister() const {
-    logger.logMessage(format("INTE [R]: %#x", interrupt.enable));
+    logger.logMessage("INTE [R]: %#x", interrupt.enable);
     return interrupt.enable;
 }
 
@@ -281,10 +280,10 @@ void CDROM::operationTest() {
             break;
         }
         default: {
-            logger.logError(format("Unhandled CDROM operation test with subfunction: %#x", subfunction));
+            logger.logError("Unhandled CDROM operation test with subfunction: %#x", subfunction);
         }
     }
-    logger.logMessage(format("CMD Test [%#x]", subfunction));
+    logger.logMessage("CMD Test [%#x]", subfunction);
 }
 
 /*
@@ -340,7 +339,7 @@ void CDROM::operationSetloc() {
     pushResponse(statusCode._value);
     interruptQueue.push(INT3);
 
-    logger.logMessage(format("CMD Setloc(%d, %d, %d)", minute, second, sector));
+    logger.logMessage("CMD Setloc(%d, %d, %d)", minute, second, sector);
 }
 
 /*

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -16,7 +16,7 @@ should be: SystemClock*930h/4/44100Hz for Single Speed (and half as much for Dou
 const uint32_t SystemClocksPerCDROMInt1SingleSpeed=2352;
 const uint32_t SystemClocksPerCDROMInt1DoubleSpeed=2352/2;
 
-CDROM::CDROM(LogLevel logLevel, unique_ptr<InterruptController> &interruptController) : logger(logLevel), interruptController(interruptController), image(), status(), interrupt(), statusCode(), mode(), parameters(), response(), interruptQueue(), seekSector(), readSector(), counter(), currentSector(), readBuffer(), readBufferIndex() {
+CDROM::CDROM(LogLevel logLevel, unique_ptr<InterruptController> &interruptController) : logger(logLevel, "  CD-ROM: "), interruptController(interruptController), image(), status(), interrupt(), statusCode(), mode(), parameters(), response(), interruptQueue(), seekSector(), readSector(), counter(), currentSector(), readBuffer(), readBufferIndex() {
 
 }
 

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -3,7 +3,6 @@
 #include <tuple>
 #include <iomanip>
 #include "CPU.tcc"
-#include "Output.hpp"
 #include "ConfigurationManager.hpp"
 
 using namespace std;
@@ -87,14 +86,14 @@ array<uint32_t, 4> CPU::getSubroutineArguments() {
 void CPU::printAllRegisters() {
     logger.logDebug("CPU Registers: ");
     for (uint i = 0; i < 32; i++) {
-        logger.logDebug(format("r%02d: %#x", i, registers[i]));
+        logger.logDebug("r%02d: %#x", i, registers[i]);
     }
-    logger.logDebug(format("status: %#x", getStatusRegister()));
-    logger.logDebug(format("lo: %#x", lowRegister));
-    logger.logDebug(format("hi: %#x", highRegister));
-    logger.logDebug(format("badvaddr: %#x", getReturnAddressFromTrap()));
-    logger.logDebug(format("cause: %#x", getCauseRegister()));
-    logger.logDebug(format("pc: %#x", programCounter));
+    logger.logDebug("status: %#x", getStatusRegister());
+    logger.logDebug("lo: %#x", lowRegister);
+    logger.logDebug("hi: %#x", highRegister);
+    logger.logDebug("badvaddr: %#x", getReturnAddressFromTrap());
+    logger.logDebug("cause: %#x", getCauseRegister());
+    logger.logDebug("pc: %#x", programCounter);
 }
 
 bool CPU::executeNextInstruction() {
@@ -547,7 +546,7 @@ void CPU::operationJumpAndLinkRegister(Instruction instruction) {
 
 void CPU::operationSystemCall(Instruction instruction) {
     if (logBiosFunctionCalls) {
-        logger.logWarning(format("  SYSCALL: %#x", registers[4]));
+        logger.logWarning("  SYSCALL: %#x", registers[4]);
     }
     triggerException(ExceptionType::SysCall);
 }
@@ -937,7 +936,7 @@ void CPU::operationCoprocessor0(Instruction instruction) {
             break;
         }
         default: {
-            logger.logError(format("Unhandled coprocessor0 instruction %#x", instruction.value));
+            logger.logError("Unhandled coprocessor0 instruction %#x", instruction.value);
         }
     }
 }
@@ -993,7 +992,7 @@ void CPU::operationMoveFromCoprocessor0(Instruction instruction) {
             break;
         }
         default: {
-            logger.logError(format("Unhandled MFC0 at index %#x", copRegisterIndex));
+            logger.logError("Unhandled MFC0 at index %#x", copRegisterIndex);
         }
     }
     loadDelaySlot(cpuRegisterIndex, value);
@@ -1043,14 +1042,14 @@ void CPU::operationMoveToCoprocessor0(Instruction instruction) {
             break;
         }
         default: {
-            logger.logError(format("Unhandled MTC0 at index %d", copRegisterIndex));
+            logger.logError("Unhandled MTC0 at index %d", copRegisterIndex);
         }
     }
 }
 
 void CPU::operationReturnFromException(Instruction instruction) {
     if (instruction.subfunct != 0b010000) {
-        logger.logError(format("Unhandled cop0 instruction (0b010000) with last 6 bits: %#x", instruction.subfunct));
+        logger.logError("Unhandled cop0 instruction (0b010000) with last 6 bits: %#x", instruction.subfunct);
     }
     cop0->status.currentInterruptEnable = cop0->status.previousInterruptEnable;
     cop0->status._currentOperationMode = cop0->status._previousOperationMode;
@@ -1064,7 +1063,7 @@ void CPU::operationCoprocessor1(Instruction instruction) {
 }
 
 void CPU::operationCoprocessor2(Instruction instruction) {
-    logger.logWarning(format("Unhandled Geometry Transformation Engine instruction: %#x", instruction.value));
+    logger.logWarning("Unhandled Geometry Transformation Engine instruction: %#x", instruction.value);
 }
 
 void CPU::operationCoprocessor3(Instruction instruction) {
@@ -1370,7 +1369,7 @@ void CPU::operationLoadWordCoprocessor1(Instruction instruction) {
 }
 
 void CPU::operationLoadWordCoprocessor2(Instruction instruction) {
-    logger.logWarning(format("Unhandled GTE LWC: %#x", instruction.value));
+    logger.logWarning("Unhandled GTE LWC: %#x", instruction.value);
 }
 
 void CPU::operationLoadWordCoprocessor3(Instruction instruction) {
@@ -1386,7 +1385,7 @@ void CPU::operationStoreWordCoprocessor1(Instruction instruction) {
 }
 
 void CPU::operationStoreWordCoprocessor2(Instruction instruction) {
-    logger.logWarning(format("Unhandled GTE SWC: %#x", instruction.value));
+    logger.logWarning("Unhandled GTE SWC: %#x", instruction.value);
 }
 
 void CPU::operationStoreWordCoprocessor3(Instruction instruction) {

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -8,7 +8,8 @@
 
 using namespace std;
 
-CPU::CPU(unique_ptr<Interconnect> &interconnect, unique_ptr<COP0> &cop0, bool logBiosFunctionCalls) : programCounter(0xbfc00000),
+CPU::CPU(LogLevel logLevel, unique_ptr<Interconnect> &interconnect, unique_ptr<COP0> &cop0, bool logBiosFunctionCalls) : logger(logLevel),
+             programCounter(0xbfc00000),
              jumpDestination(0),
              isBranching(false),
              runningException(false),
@@ -84,16 +85,16 @@ array<uint32_t, 4> CPU::getSubroutineArguments() {
 }
 
 void CPU::printAllRegisters() {
-    printWarning("CPU Registers: ");
+    logger.logDebug("CPU Registers: ");
     for (uint i = 0; i < 32; i++) {
-        printWarning("r%02d: %#x", i, registers[i]);
+        logger.logDebug(format("r%02d: %#x", i, registers[i]));
     }
-    printWarning("status: %#x", getStatusRegister());
-    printWarning("lo: %#x", lowRegister);
-    printWarning("hi: %#x", highRegister);
-    printWarning("badvaddr: %#x", getReturnAddressFromTrap());
-    printWarning("cause: %#x", getCauseRegister());
-    printWarning("pc: %#x", programCounter);
+    logger.logDebug(format("status: %#x", getStatusRegister()));
+    logger.logDebug(format("lo: %#x", lowRegister));
+    logger.logDebug(format("hi: %#x", highRegister));
+    logger.logDebug(format("badvaddr: %#x", getReturnAddressFromTrap()));
+    logger.logDebug(format("cause: %#x", getCauseRegister()));
+    logger.logDebug(format("pc: %#x", programCounter));
 }
 
 bool CPU::executeNextInstruction() {
@@ -546,7 +547,7 @@ void CPU::operationJumpAndLinkRegister(Instruction instruction) {
 
 void CPU::operationSystemCall(Instruction instruction) {
     if (logBiosFunctionCalls) {
-        printWarning("  SYSCALL: %#x", registers[4]);
+        logger.logWarning(format("  SYSCALL: %#x", registers[4]));
     }
     triggerException(ExceptionType::SysCall);
 }
@@ -936,7 +937,7 @@ void CPU::operationCoprocessor0(Instruction instruction) {
             break;
         }
         default: {
-            printError("Unhandled coprocessor0 instruction %#x", instruction.value);
+            logger.logError(format("Unhandled coprocessor0 instruction %#x", instruction.value));
         }
     }
 }
@@ -992,7 +993,7 @@ void CPU::operationMoveFromCoprocessor0(Instruction instruction) {
             break;
         }
         default: {
-            printError("Unhandled MFC0 at index %#x", copRegisterIndex);
+            logger.logError(format("Unhandled MFC0 at index %#x", copRegisterIndex));
         }
     }
     loadDelaySlot(cpuRegisterIndex, value);
@@ -1042,14 +1043,14 @@ void CPU::operationMoveToCoprocessor0(Instruction instruction) {
             break;
         }
         default: {
-            printError("Unhandled MTC0 at index %d", copRegisterIndex);
+            logger.logError(format("Unhandled MTC0 at index %d", copRegisterIndex));
         }
     }
 }
 
 void CPU::operationReturnFromException(Instruction instruction) {
     if (instruction.subfunct != 0b010000) {
-        printError("Unhandled cop0 instruction (0b010000) with last 6 bits: %#x", instruction.subfunct);
+        logger.logError(format("Unhandled cop0 instruction (0b010000) with last 6 bits: %#x", instruction.subfunct));
     }
     cop0->status.currentInterruptEnable = cop0->status.previousInterruptEnable;
     cop0->status._currentOperationMode = cop0->status._previousOperationMode;
@@ -1063,7 +1064,7 @@ void CPU::operationCoprocessor1(Instruction instruction) {
 }
 
 void CPU::operationCoprocessor2(Instruction instruction) {
-    printWarning("Unhandled Geometry Transformation Engine instruction: %#x", instruction.value);
+    logger.logWarning(format("Unhandled Geometry Transformation Engine instruction: %#x", instruction.value));
 }
 
 void CPU::operationCoprocessor3(Instruction instruction) {
@@ -1369,7 +1370,7 @@ void CPU::operationLoadWordCoprocessor1(Instruction instruction) {
 }
 
 void CPU::operationLoadWordCoprocessor2(Instruction instruction) {
-    printWarning("Unhandled GTE LWC: %#x", instruction.value);
+    logger.logWarning(format("Unhandled GTE LWC: %#x", instruction.value));
 }
 
 void CPU::operationLoadWordCoprocessor3(Instruction instruction) {
@@ -1385,7 +1386,7 @@ void CPU::operationStoreWordCoprocessor1(Instruction instruction) {
 }
 
 void CPU::operationStoreWordCoprocessor2(Instruction instruction) {
-    printWarning("Unhandled GTE SWC: %#x", instruction.value);
+    logger.logWarning(format("Unhandled GTE SWC: %#x", instruction.value));
 }
 
 void CPU::operationStoreWordCoprocessor3(Instruction instruction) {

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -1,5 +1,4 @@
 #include "Channel.hpp"
-#include "Output.hpp"
 
 using namespace std;
 

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-Channel::Channel() {
+Channel::Channel() : control(), baseAddress(), blockControl(), logger(LogLevel::NoLog) {
 
 }
 
@@ -91,7 +91,7 @@ optional<uint32_t> Channel::transferSize() const {
             return { blockControl.blockSize * blockControl.blockCount };
         }
         default: {
-            printError("Unknown DMA sync mode");
+            logger.logError("Unknown DMA sync mode");
             return {0};
         }
     }

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -76,6 +76,9 @@ void ConfigurationManager::loadConfiguration() {
     cpu = logLevelWithValue(configuration["log"]["cpu"].As<string>());
     gpu = logLevelWithValue(configuration["log"]["gpu"].As<string>());
     trace = configuration["log"]["trace"].As<bool>();
+    if (trace) {
+        remove("ruby.log");
+    }
 }
 
 bool ConfigurationManager::shouldResizeWindowToFitFramebuffer() {

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -1,6 +1,5 @@
 #include "ConfigurationManager.hpp"
 #include <fstream>
-#include "Output.hpp"
 #include <unistd.h>
 #include <sys/types.h>
 #include <pwd.h>
@@ -45,7 +44,7 @@ void ConfigurationManager::setupConfigurationFile() {
     logger.logWarning("Generating default configuration at global path");
     if (mkdir(globalConfigurationDir.c_str(), 0777) == -1) {
         if (errno != EEXIST) {
-            logger.logError(format("Couldn't create a directory for global config with errno: %s", strerror(errno)));
+            logger.logError("Couldn't create a directory for global config with errno: %s", strerror(errno));
         }
     }
     Yaml::Node logConfiguration = Yaml::Node();

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 const string configurationFile = "config.yaml";
 
-ConfigurationManager::ConfigurationManager() : logger(LogLevel::Warning, false), filePath(), resizeWindowToFitFramefuffer(false), showDebugInfoWindow(false),  bios(NoLog), cdrom(NoLog), interconnect(NoLog), cpu(NoLog), gpu(NoLog), trace(false) {}
+ConfigurationManager::ConfigurationManager() : logger(LogLevel::Warning, "", false), filePath(), resizeWindowToFitFramefuffer(false), showDebugInfoWindow(false),  bios(NoLog), cdrom(NoLog), interconnect(NoLog), cpu(NoLog), gpu(NoLog), trace(false) {}
 
 ConfigurationManager* ConfigurationManager::instance = nullptr;
 

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -55,6 +55,7 @@ void ConfigurationManager::setupConfigurationFile() {
     logConfigurationRef["interconnect"] = "OFF";
     logConfigurationRef["cpu"] = "OFF";
     logConfigurationRef["gpu"] = "OFF";
+    logConfigurationRef["opengl"] = "OFF";
     logConfigurationRef["trace"] = "false";
     Yaml::Node configuration = Yaml::Node();
     Yaml::Node &configurationRef = configuration;
@@ -75,6 +76,7 @@ void ConfigurationManager::loadConfiguration() {
     interconnect = logLevelWithValue(configuration["log"]["interconnect"].As<string>());
     cpu = logLevelWithValue(configuration["log"]["cpu"].As<string>());
     gpu = logLevelWithValue(configuration["log"]["gpu"].As<string>());
+    opengl = logLevelWithValue(configuration["log"]["opengl"].As<string>());
     trace = configuration["log"]["trace"].As<bool>();
     if (trace) {
         remove("ruby.log");
@@ -107,6 +109,10 @@ LogLevel ConfigurationManager::cpuLogLevel() {
 
 LogLevel ConfigurationManager::gpuLogLevel() {
     return gpu;
+}
+
+LogLevel ConfigurationManager::openGLLogLevel() {
+    return opengl;
 }
 
 bool ConfigurationManager::shouldTraceLogs() {

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1,6 +1,6 @@
 #include "Controller.hpp"
 
-Controller::Controller() : control(), joypadBaud(), mode(), rxData(), status(), txData() {
+Controller::Controller() : logger(LogLevel::NoLog), control(), joypadBaud(), mode(), rxData(), status(), txData() {
 
 }
 

--- a/src/DMA.cpp
+++ b/src/DMA.cpp
@@ -1,38 +1,8 @@
 #include "DMA.hpp"
-#include "Output.hpp"
 #include "RAM.tcc"
 #include <iostream>
 
 using namespace std;
-
-Port portWithIndex(uint32_t index) {
-    if (index > Port::OTC) {
-        cout << format("Attempting to get port with out-of-bounds index: %d", index) << endl;
-        exit(1);
-    }
-    return Port(index);
-}
-
-string portDescription(Port port) {
-    switch (port) {
-        case MDECin:
-            return "MDECin";
-        case MDECout:
-            return "MDECout";
-        case GPUP:
-            return "GPU";
-        case CDROMP:
-            return "CDROM";
-        case SPU:
-            return "SPU";
-        case PIO:
-            return "PIO";
-        case OTC:
-            return "OTC";
-        case None:
-            return "None";
-    }
-}
 
 DMA::DMA(unique_ptr<RAM> &ram, unique_ptr<GPU> &gpu, unique_ptr<CDROM> &cdrom) : logger(LogLevel::NoLog), ram(ram), gpu(gpu), cdrom(cdrom) {
     for (int i = 0; i < 7; i++) {
@@ -94,7 +64,7 @@ void DMA::execute(Port port) {
 void DMA::executeLinkedList(Port port, Channel& channel) {
     uint32_t address = channel.baseAddressRegister() & 0x1ffffc;
     if (port != Port::GPUP) {
-        logger.logError(format("Unhandled DMA linked-list transfer with port: %s", portDescription(port).c_str()));
+        logger.logError("Unhandled DMA linked-list transfer with port: %s", portDescription(port).c_str());
     }
     if (channel.direction() == Direction::ToRam) {
         logger.logError("Unhandled DMA linked-list transfer to RAM");
@@ -139,7 +109,7 @@ void DMA::executeBlock(Port port, Channel& channel) {
                         break;
                     }
                     default: {
-                        logger.logError(format("Unhandled DMA block transfer from RAM to source port: %s", portDescription(port).c_str()));
+                        logger.logError("Unhandled DMA block transfer from RAM to source port: %s", portDescription(port).c_str());
                         break;
                     }
                 }
@@ -166,7 +136,7 @@ void DMA::executeBlock(Port port, Channel& channel) {
                         break;
                     }
                     default: {
-                        logger.logError(format("Unhandled DMA block transfer to RAM from source port: %s", portDescription(port).c_str()));
+                        logger.logError("Unhandled DMA block transfer to RAM from source port: %s", portDescription(port).c_str());
                         break;
                     }
                 }
@@ -179,4 +149,32 @@ void DMA::executeBlock(Port port, Channel& channel) {
     }
     channel.done();
     return;
+}
+
+Port DMA::portWithIndex(uint32_t index) {
+    if (index > Port::OTC) {
+        logger.logError("Attempting to get port with out-of-bounds index: %d", index);
+    }
+    return Port(index);
+}
+
+string DMA::portDescription(Port port) {
+    switch (port) {
+        case MDECin:
+            return "MDECin";
+        case MDECout:
+            return "MDECout";
+        case GPUP:
+            return "GPU";
+        case CDROMP:
+            return "CDROM";
+        case SPU:
+            return "SPU";
+        case PIO:
+            return "PIO";
+        case OTC:
+            return "OTC";
+        case None:
+            return "None";
+    }
 }

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -4,7 +4,6 @@
 #include "Constants.h"
 #include <SDL2/SDL.h>
 #include <glad/glad.h>
-#include "Output.hpp"
 
 using namespace std;
 
@@ -103,7 +102,7 @@ void Emulator::dumpRAM() {
 
 void Emulator::setupSDL() {
     if (SDL_Init(SDL_INIT_VIDEO) != 0) {
-        logger.logError(format("Error initializing SDL: %s", SDL_GetError()));
+        logger.logError("Error initializing SDL: %s", SDL_GetError());
     }
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 5);
@@ -112,7 +111,7 @@ void Emulator::setupSDL() {
 
 void Emulator::setupOpenGL() {
     if (!gladLoadGLLoader((GLADloadproc) SDL_GL_GetProcAddress)) {
-        logger.logError(format("Failed to initialize the OpenGL context."));
+        logger.logError("Failed to initialize the OpenGL context.");
     }
 }
 
@@ -141,7 +140,7 @@ void Emulator::loadCDROMImageFile(string filePath) {
 
 void Emulator::checkTTY(char c) {
     if (c == '\n') {
-        logger.logDebug(format("%s", ttyBuffer.c_str()));
+        logger.logDebug("%s", ttyBuffer.c_str());
         ttyBuffer.clear();
         return;
     }

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -11,7 +11,7 @@ using namespace std;
 const uint32_t SCREEN_WIDTH = 1024;
 const uint32_t SCREEN_HEIGHT = 768;
 
-Emulator::Emulator() : ttyBuffer(), biosFunctionsLog() {
+Emulator::Emulator() : logger(LogLevel::NoLog), ttyBuffer(), biosFunctionsLog() {
     setupSDL();
     uint32_t screenHeight = SCREEN_HEIGHT;
     ConfigurationManager *configurationManager = ConfigurationManager::getInstance();
@@ -22,7 +22,6 @@ Emulator::Emulator() : ttyBuffer(), biosFunctionsLog() {
     if (showDebugInfoWindow) {
         debugWindow = make_unique<Window>(false, "ルビィ - dbginfo", SCREEN_WIDTH, SCREEN_HEIGHT);
     }
-    logBiosFunctionCalls = configurationManager->shouldLogBiosFunctionCalls();
     mainWindow = make_unique<Window>(true, "ルビィ", SCREEN_WIDTH, screenHeight);
     mainWindow->makeCurrent();
     setupOpenGL();
@@ -30,20 +29,21 @@ Emulator::Emulator() : ttyBuffer(), biosFunctionsLog() {
         debugInfoRenderer = make_unique<DebugInfoRenderer>(debugWindow);
     }
     cop0 = make_unique<COP0>();
-    bios = make_unique<BIOS>();
+    bios = make_unique<BIOS>(configurationManager->biosLogLevel());
     ram = make_unique<RAM>();
-    gpu = make_unique<GPU>(mainWindow);
+    gpu = make_unique<GPU>(configurationManager->gpuLogLevel(), mainWindow);
     scratchpad = make_unique<Scratchpad>();
     interruptController = make_unique<InterruptController>(cop0);
-    cdrom = make_unique<CDROM>(interruptController, configurationManager->shouldLogCDROMActivity());
+    LogLevel cdromLogLevel = configurationManager->cdromLogLevel();
+    cdrom = make_unique<CDROM>(cdromLogLevel, interruptController);
     dma = make_unique<DMA>(ram, gpu, cdrom);
     expansion1 = make_unique<Expansion1>();
     timer0 = make_unique<Timer0>();
     timer1 = make_unique<Timer1>();
     timer2 = make_unique<Timer2>();
     controller = make_unique<Controller>();
-    interconnect = make_unique<Interconnect>(cop0, bios, ram, gpu, dma, scratchpad, cdrom, interruptController, expansion1, timer0, timer1, timer2, controller);
-    cpu = make_unique<CPU>(interconnect, cop0, logBiosFunctionCalls);
+    interconnect = make_unique<Interconnect>(configurationManager->interconnectLogLevel(), cop0, bios, ram, gpu, dma, scratchpad, cdrom, interruptController, expansion1, timer0, timer1, timer2, controller);
+    cpu = make_unique<CPU>(configurationManager->cpuLogLevel(), interconnect, cop0, logBiosFunctionCalls);
 }
 
 Emulator::~Emulator() {}
@@ -103,7 +103,7 @@ void Emulator::dumpRAM() {
 
 void Emulator::setupSDL() {
     if (SDL_Init(SDL_INIT_VIDEO) != 0) {
-        printError("Error initializing SDL: %s", SDL_GetError());
+        logger.logError(format("Error initializing SDL: %s", SDL_GetError()));
     }
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 5);
@@ -112,7 +112,7 @@ void Emulator::setupSDL() {
 
 void Emulator::setupOpenGL() {
     if (!gladLoadGLLoader((GLADloadproc) SDL_GL_GetProcAddress)) {
-        printError("Failed to initialize the OpenGL context.");
+        logger.logError(format("Failed to initialize the OpenGL context."));
     }
 }
 
@@ -141,7 +141,7 @@ void Emulator::loadCDROMImageFile(string filePath) {
 
 void Emulator::checkTTY(char c) {
     if (c == '\n') {
-        printWarning("%s", ttyBuffer.c_str());
+        logger.logDebug(format("%s", ttyBuffer.c_str()));
         ttyBuffer.clear();
         return;
     }
@@ -160,14 +160,6 @@ void Emulator::checkBIOSFunctions() {
     bool functionCallLogIsRFE = functionCallLog.find("ReturnFromException()") == 0;
     if (functionCallLog.find("std_out_putchar(char)") == 0) {
         checkTTY(registers[4]);
-    } else {
-        if (logBiosFunctionCalls) {
-            if (!functionCallLogIsRFE) {
-                printWarning("  BIOS: %s", functionCallLog.c_str());
-            }
-        }
     }
-    if (!functionCallLogIsRFE) {
-        biosFunctionsLog.push_back(functionCallLog);
-    }
+    biosFunctionsLog.push_back(functionCallLog);
 }

--- a/src/EmulatorRunner.cpp
+++ b/src/EmulatorRunner.cpp
@@ -1,7 +1,6 @@
 #include "EmulatorRunner.hpp"
 #include <fstream>
 #include <algorithm>
-#include "Output.hpp"
 #include "CPU.hpp"
 
 using namespace std;

--- a/src/EmulatorRunner.cpp
+++ b/src/EmulatorRunner.cpp
@@ -6,7 +6,7 @@
 
 using namespace std;
 
-EmulatorRunner::EmulatorRunner() : emulator(nullptr), runTests(false), exeFile(), binFile(), header() {}
+EmulatorRunner::EmulatorRunner() : logger(LogLevel::NoLog), emulator(nullptr), runTests(false), exeFile(), binFile(), header() {}
 
 EmulatorRunner* EmulatorRunner::instance = nullptr;
 
@@ -37,7 +37,7 @@ void EmulatorRunner::configure(int argc, char* argv[]) {
     if (checkOption(argv, argv + argc, "--exe")) {
         char *path = getOptionValue(argv, argv + argc, "--exe");
         if (path == NULL) {
-            printError("Incorrect argument passed. See README.md for usage.");
+            logger.logError("Incorrect argument passed. See README.md for usage.");
         }
         runTests = true;
         exeFile = string(path);
@@ -46,13 +46,13 @@ void EmulatorRunner::configure(int argc, char* argv[]) {
     if (checkOption(argv, argv + argc, "--bin")) {
         char *path = getOptionValue(argv, argv + argc, "--bin");
         if (path == NULL) {
-            printError("Incorrect argument passed. See README.md for usage.");
+            logger.logError("Incorrect argument passed. See README.md for usage.");
         }
         binFile = string(path);
         argumentFound = true;
     }
     if (!argumentFound) {
-        printError("Incorrect argument passed. See README.md for usage.");
+        logger.logError("Incorrect argument passed. See README.md for usage.");
     }
 }
 
@@ -64,7 +64,7 @@ void EmulatorRunner::setEmulator(Emulator *emulator) {
 void EmulatorRunner::readHeader() {
     ifstream file = ifstream(exeFile, ios::in|ios::binary|ios::ate);
     if (!file.is_open()) {
-        printError("Unable to tests.exe binary");
+        logger.logError("Unable to tests.exe binary");
     }
     file.seekg(0, ios::beg);
     file.read(reinterpret_cast<char *>(header), TEST_HEADER_SIZE);
@@ -118,12 +118,12 @@ void EmulatorRunner::setup() {
     readHeader();
     string identifier = id();
     if (identifier.compare("PS-X EXE") != 0) {
-        printError("Invalid identifier found in file header");
+        logger.logError("Invalid identifier found in file header");
     }
     uint32_t destinationAddress = this->destinationAddress();
     uint32_t fileSize = this->fileSize();
     if (fileSize % 0x800 != 0) {
-        printError("Invalid file size found in file header");
+        logger.logError("Invalid file size found in file header");
     }
     emulator->transferToRAM(exeFile, 0x800, fileSize, destinationAddress);
 

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -1,23 +1,10 @@
 #include "GPU.hpp"
-#include "Output.hpp"
 #include "Vertex.hpp"
 #include <iostream>
 
 using namespace std;
 
 const uint32_t GP0_COMMAND_TERMINATION_CODE = 0x55555555;
-
-uint8_t horizontalResolutionFromValues(uint8_t value1, uint8_t value2) {
-    return ((value2 & 1) | ((value1 & 3) << 1));
-}
-
-TexturePageColors texturePageColorsWithValue(uint32_t value) {
-    if (value > TexturePageColors::T15Bit) {
-        cout << format("Attempting to create Texture Page Colors out-of-bounds value: %#x", value) << endl;
-        exit(1);
-    }
-    return TexturePageColors(value);
-}
 
 GPU::GPU(LogLevel logLevel, std::unique_ptr<Window> &mainWindow) : logger(logLevel),
              texturePageBaseX(0),
@@ -565,7 +552,7 @@ void GPU::executeGp0(uint32_t value) {
                 break;
             }
             default: {
-                logger.logError(format("Unhandled gp0 instruction %#x", opCode));
+                logger.logError("Unhandled gp0 instruction %#x", opCode);
             }
         }
         gp0InstructionBuffer.clear();
@@ -673,7 +660,7 @@ void GPU::executeGp1(uint32_t value) {
             break;
         }
         default: {
-            logger.logError(format("Unhandled gp1 instruction %#x", opCode));
+            logger.logError("Unhandled gp1 instruction %#x", opCode);
         }
     }
 }
@@ -963,7 +950,7 @@ void GPU::operationGp0CopyRectangleVRAMToCPU() {
     uint32_t width = resolution & 0xffff;
     uint32_t height = resolution >> 16;
 
-    logger.logWarning(format("Unhandled GP0 Copy Rectangle VRAM to CPU with with resolution: %d x %d", width, height));
+    logger.logWarning("Unhandled GP0 Copy Rectangle VRAM to CPU with with resolution: %d x %d", width, height);
 }
 
 /*
@@ -1925,4 +1912,15 @@ void GPU::shadedLine(uint numberOfPoints, bool opaque) {
         renderer->pushLine(lines);
         lines.clear();
     }
+}
+
+uint8_t GPU::horizontalResolutionFromValues(uint8_t value1, uint8_t value2) const {
+    return ((value2 & 1) | ((value1 & 3) << 1));
+}
+
+TexturePageColors GPU::texturePageColorsWithValue(uint32_t value) const {
+    if (value > TexturePageColors::T15Bit) {
+        logger.logError("Attempting to create Texture Page Colors out-of-bounds value: %#x", value);
+    }
+    return TexturePageColors(value);
 }

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -1,6 +1,7 @@
 #include "GPU.hpp"
 #include "Output.hpp"
 #include "Vertex.hpp"
+#include <iostream>
 
 using namespace std;
 
@@ -12,12 +13,14 @@ uint8_t horizontalResolutionFromValues(uint8_t value1, uint8_t value2) {
 
 TexturePageColors texturePageColorsWithValue(uint32_t value) {
     if (value > TexturePageColors::T15Bit) {
-        printError("Attempting to create Texture Page Colors out-of-bounds value: %#x", value);
+        cout << format("Attempting to create Texture Page Colors out-of-bounds value: %#x", value) << endl;
+        exit(1);
     }
     return TexturePageColors(value);
 }
 
-GPU::GPU(std::unique_ptr<Window> &mainWindow) : texturePageBaseX(0),
+GPU::GPU(LogLevel logLevel, std::unique_ptr<Window> &mainWindow) : logger(logLevel),
+             texturePageBaseX(0),
              texturePageBaseY(0),
              semiTransparency(0),
              texturePageColors(TexturePageColors::T4Bit),
@@ -562,7 +565,7 @@ void GPU::executeGp0(uint32_t value) {
                 break;
             }
             default: {
-                printError("Unhandled gp0 instruction %#x", opCode);
+                logger.logError(format("Unhandled gp0 instruction %#x", opCode));
             }
         }
         gp0InstructionBuffer.clear();
@@ -670,7 +673,7 @@ void GPU::executeGp1(uint32_t value) {
             break;
         }
         default: {
-            printError("Unhandled gp1 instruction %#x", opCode);
+            logger.logError(format("Unhandled gp1 instruction %#x", opCode));
         }
     }
 }
@@ -789,7 +792,7 @@ void GPU::operationGp1DisplayMode(uint32_t value) {
     verticalInterlaceEnable = (value >> 5) & 0x1;
     if ((value & 0x80) != 0) {
         // This is supposed to be bit 14 on GPUSTAT
-        printError("Unsupported display mode: distorted");
+        logger.logError("Unsupported display mode: distorted");
     }
 }
 
@@ -960,7 +963,7 @@ void GPU::operationGp0CopyRectangleVRAMToCPU() {
     uint32_t width = resolution & 0xffff;
     uint32_t height = resolution >> 16;
 
-    printWarning("Unhandled GP0 Copy Rectangle VRAM to CPU with with resolution: %d x %d", width, height);
+    logger.logWarning(format("Unhandled GP0 Copy Rectangle VRAM to CPU with with resolution: %d x %d", width, height));
 }
 
 /*
@@ -1681,7 +1684,7 @@ void GPU::operationGp1ResetCommandBuffer(uint32_t value) {
     gp0InstructionBuffer.clear();
     gp0WordsRemaining = 0;
     gp0Mode = GP0Mode::Command;
-    printWarning("TODO: clear the command FIFO");
+    logger.logWarning("TODO: clear the command FIFO");
 }
 
 /*

--- a/src/GPUInstructionBuffer.cpp
+++ b/src/GPUInstructionBuffer.cpp
@@ -1,6 +1,7 @@
 #include "GPUInstructionBuffer.hpp"
 #include <algorithm>
 #include "Output.hpp"
+#include <iostream>
 
 using namespace std;
 
@@ -14,7 +15,8 @@ GPUInstructionBuffer::~GPUInstructionBuffer() {
 
 uint32_t& GPUInstructionBuffer::operator[] (const uint8_t index) {
     if (index >= length) {
-        printError("GPU Instruction Buffer index-out-of-bounds: %d", index);
+        cout << format("GPU Instruction Buffer index-out-of-bounds: %d", index) << endl;
+        exit(1);
     }
     return buffer[index];
 }

--- a/src/GPUInstructionBuffer.cpp
+++ b/src/GPUInstructionBuffer.cpp
@@ -1,11 +1,10 @@
 #include "GPUInstructionBuffer.hpp"
 #include <algorithm>
-#include "Output.hpp"
 #include <iostream>
 
 using namespace std;
 
-GPUInstructionBuffer::GPUInstructionBuffer() {
+GPUInstructionBuffer::GPUInstructionBuffer() : logger(LogLevel::NoLog) {
 
 }
 
@@ -15,8 +14,7 @@ GPUInstructionBuffer::~GPUInstructionBuffer() {
 
 uint32_t& GPUInstructionBuffer::operator[] (const uint8_t index) {
     if (index >= length) {
-        cout << format("GPU Instruction Buffer index-out-of-bounds: %d", index) << endl;
-        exit(1);
+        logger.logError("GPU Instruction Buffer index-out-of-bounds: %d", index);
     }
     return buffer[index];
 }

--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -1,13 +1,15 @@
 #include "Helpers.hpp"
 #include <fstream>
 #include "Output.hpp"
+#include <iostream>
 
 using namespace std;
 
 void readBinary(const string& path, uint8_t *data) {
     ifstream file = ifstream(path, ios::in|ios::binary|ios::ate);
     if (!file.is_open()) {
-        printError("Unable to load BIOS");
+        cout << format("Unable to load binary at path %s", path.c_str()) << endl;
+        exit(1);
     }
     streampos size = file.tellg();
     file.seekg(0, ios::beg);

--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -5,16 +5,20 @@
 
 using namespace std;
 
-void readBinary(const string& path, uint8_t *data) {
-    ifstream file = ifstream(path, ios::in|ios::binary|ios::ate);
+void readBinary(const std::string& path, uint8_t *data, uint32_t atOrigin) {
+    ifstream file = ifstream(path, ios::in | ios::binary | ios::ate);
     if (!file.is_open()) {
         cout << format("Unable to load binary at path %s", path.c_str()) << endl;
         exit(1);
     }
     streampos size = file.tellg();
-    file.seekg(0, ios::beg);
+    file.seekg(atOrigin, ios::beg);
     file.read(reinterpret_cast<char *>(data), size);
     file.close();
+}
+
+void readBinary(const string& path, uint8_t *data) {
+    readBinary(path, data, 0);
 }
 
 uint8_t decimalFromBCDEncodedInt(uint8_t bcdEncoded) {

--- a/src/Interconnect.cpp
+++ b/src/Interconnect.cpp
@@ -15,7 +15,7 @@ const uint32_t regionMask[8] = {
     0xffffffff, 0xffffffff,
 };
 
-Interconnect::Interconnect(std::unique_ptr<COP0> &cop0, unique_ptr<BIOS> &bios, unique_ptr<RAM> &ram, unique_ptr<GPU> &gpu, unique_ptr<DMA> &dma, unique_ptr<Scratchpad> &scratchpad, unique_ptr<CDROM> &cdrom, unique_ptr<InterruptController> &interruptController, unique_ptr<Expansion1> &expansion1, std::unique_ptr<Timer0> &timer0, std::unique_ptr<Timer1> &timer1, std::unique_ptr<Timer2> &timer2, std::unique_ptr<Controller> &controller) : cop0(cop0), bios(bios), ram(ram), gpu(gpu), dma(dma), scratchpad(scratchpad), cdrom(cdrom), interruptController(interruptController), expansion1(expansion1), timer0(timer0), timer1(timer1), timer2(timer2), controller(controller) {
+Interconnect::Interconnect(LogLevel logLevel, std::unique_ptr<COP0> &cop0, unique_ptr<BIOS> &bios, unique_ptr<RAM> &ram, unique_ptr<GPU> &gpu, unique_ptr<DMA> &dma, unique_ptr<Scratchpad> &scratchpad, unique_ptr<CDROM> &cdrom, unique_ptr<InterruptController> &interruptController, unique_ptr<Expansion1> &expansion1, std::unique_ptr<Timer0> &timer0, std::unique_ptr<Timer1> &timer1, std::unique_ptr<Timer2> &timer2, std::unique_ptr<Controller> &controller) : logger(logLevel), cop0(cop0), bios(bios), ram(ram), gpu(gpu), dma(dma), scratchpad(scratchpad), cdrom(cdrom), interruptController(interruptController), expansion1(expansion1), timer0(timer0), timer1(timer1), timer2(timer2), controller(controller) {
     bios->loadBin("SCPH1001.BIN");
     EmulatorRunner *emulatorRunner = EmulatorRunner::getInstance();
     if (emulatorRunner->shouldRunTests()) {

--- a/src/InterruptController.cpp
+++ b/src/InterruptController.cpp
@@ -2,7 +2,7 @@
 
 using namespace std;
 
-InterruptController::InterruptController(unique_ptr<COP0> &cop0) : cop0(cop0), status(), mask() {
+InterruptController::InterruptController(unique_ptr<COP0> &cop0) : logger(LogLevel::NoLog), cop0(cop0), status(), mask() {
 
 }
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -28,13 +28,6 @@ Logger::Logger(LogLevel level) : level(level) {
 
 Logger::Logger(LogLevel level, bool shouldTrace) : level(level), shouldTrace(shouldTrace) {}
 
-void Logger::setupTraceFile() {
-    if (!shouldTrace) {
-        return;
-    }
-    remove("ruby.log");
-}
-
 void Logger::flush() const {
     ofstream logfile = ofstream();
     logfile.open("ruby.log", ios::out | ios::app);

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,6 +1,7 @@
 #include "Logger.hpp"
 #include <fstream>
 #include <iostream>
+#include "Output.hpp"
 #include "ConfigurationManager.hpp"
 
 using namespace std;
@@ -49,30 +50,50 @@ void Logger::traceMessage(std::string message) const {
     flush();
 }
 
-void Logger::logDebug(std::string message) const {
-    cout << message << endl;
-    traceMessage(message);
+void Logger::logDebug(const char *fmt, ...) const {
+    va_list args;
+    va_start(args, fmt);
+    string formatted = format(fmt, args);
+    va_end(args);
+
+    cout << formatted << endl;
+    traceMessage(formatted);
 }
 
-void Logger::logMessage(std::string message) const {
+void Logger::logMessage(const char *fmt, ...) const {
     if (level < LogLevel::Message) {
         return;
     }
-    cout << message << endl;
-    traceMessage(message);
+    va_list args;
+    va_start(args, fmt);
+    string formatted = format(fmt, args);
+    va_end(args);
+
+    cout << formatted << endl;
+    traceMessage(formatted);
 }
 
-void Logger::logWarning(std::string message) const {
+void Logger::logWarning(const char *fmt, ...) const {
     if (level < LogLevel::Warning) {
         return;
     }
-    cout << message << endl;
-    traceMessage(message);
+    va_list args;
+    va_start(args, fmt);
+    string formatted = format(fmt, args);
+    va_end(args);
+
+    cout << formatted << endl;
+    traceMessage(formatted);
 }
 
-void Logger::logError(std::string message) const {
-    cout << message << endl;
-    traceMessage(message);
+void Logger::logError(const char *fmt, ...) const {
+    va_list args;
+    va_start(args, fmt);
+    string formatted = format(fmt, args);
+    va_end(args);
+
+    cout << formatted << endl;
+    traceMessage(formatted);
     flush();
     exit(1);
 }

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -22,12 +22,17 @@ LogLevel logLevelWithValue(std::string value) {
     return LogLevel::NoLog;
 }
 
-Logger::Logger(LogLevel level) : level(level) {
+Logger::Logger(LogLevel level) : level(level), prefix("") {
     ConfigurationManager *configurationManager = ConfigurationManager::getInstance();
     shouldTrace = configurationManager->shouldTraceLogs();
 }
 
-Logger::Logger(LogLevel level, bool shouldTrace) : level(level), shouldTrace(shouldTrace) {}
+Logger::Logger(LogLevel level, string prefix) : level(level), prefix(prefix) {
+    ConfigurationManager *configurationManager = ConfigurationManager::getInstance();
+    shouldTrace = configurationManager->shouldTraceLogs();
+}
+
+Logger::Logger(LogLevel level, string prefix, bool shouldTrace) : level(level), prefix(prefix), shouldTrace(shouldTrace) {}
 
 void Logger::flush() const {
     ofstream logfile = ofstream();
@@ -56,6 +61,7 @@ void Logger::logDebug(const char *fmt, ...) const {
     string formatted = format(fmt, args);
     va_end(args);
 
+    formatted.insert(0, prefix);
     cout << formatted << endl;
     traceMessage(formatted);
 }
@@ -69,6 +75,7 @@ void Logger::logMessage(const char *fmt, ...) const {
     string formatted = format(fmt, args);
     va_end(args);
 
+    formatted.insert(0, prefix);
     cout << formatted << endl;
     traceMessage(formatted);
 }
@@ -82,6 +89,7 @@ void Logger::logWarning(const char *fmt, ...) const {
     string formatted = format(fmt, args);
     va_end(args);
 
+    formatted.insert(0, prefix);
     cout << formatted << endl;
     traceMessage(formatted);
 }
@@ -92,6 +100,7 @@ void Logger::logError(const char *fmt, ...) const {
     string formatted = format(fmt, args);
     va_end(args);
 
+    formatted.insert(0, prefix);
     cout << formatted << endl;
     traceMessage(formatted);
     flush();

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -33,33 +33,3 @@ string format(const char *fmt, ...) {
     va_end(args);
     return formatted;
 }
-
-void printMessage(const char *fmt, ...) {
-    va_list args;
-    va_start(args, fmt);
-    string formatted = format(fmt, args);
-    va_end(args);
-    Logger *logger = Logger::getInstance();
-    logger->logMessage(formatted);
-}
-
-void printWarning(const char *fmt, ...) {
-    va_list args;
-    va_start(args, fmt);
-    string formatted = format(fmt, args);
-    va_end(args);
-    Logger *logger = Logger::getInstance();
-    logger->logWarning(formatted);
-}
-
-void printError(const char *fmt, ...) {
-    va_list args;
-    va_start(args, fmt);
-    string formatted = format(fmt, args);
-    va_end(args);
-    Logger *logger = Logger::getInstance();
-    logger->logError(formatted);
-    Debugger *debugger = Debugger::getInstance();
-    debugger->debug();
-    exit(1);
-}

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -1,8 +1,4 @@
 #include "Output.hpp"
-#include <cstdarg>
-#include "EmulatorRunner.hpp"
-#include "Logger.hpp"
-#include <sstream>
 
 using namespace std;
 

--- a/src/RAM.cpp
+++ b/src/RAM.cpp
@@ -1,7 +1,6 @@
 #include "RAM.hpp"
 #include <algorithm>
 #include <fstream>
-#include "Output.hpp"
 #include "Helpers.hpp"
 
 using namespace std;

--- a/src/RAM.cpp
+++ b/src/RAM.cpp
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <fstream>
 #include "Output.hpp"
-#include <iostream>
+#include "Helpers.hpp"
 
 using namespace std;
 
@@ -14,14 +14,8 @@ RAM::~RAM() {
 }
 
 void RAM::receiveTransfer(std::string path, uint32_t origin, uint32_t size, uint32_t destination) {
-    ifstream file (path, ios::in|ios::binary|ios::ate);
-    if (!file.is_open()) {
-        cout << "Unable to load binary" << endl;
-    }
-    file.seekg(origin);
     uint8_t *dataDestination = &data[destination];
-    file.read(reinterpret_cast<char *>(dataDestination), size);
-    file.close();
+    readBinary(path, dataDestination, origin);
 }
 
 void RAM::dump() {

--- a/src/RAM.cpp
+++ b/src/RAM.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <fstream>
 #include "Output.hpp"
+#include <iostream>
 
 using namespace std;
 
@@ -15,7 +16,7 @@ RAM::~RAM() {
 void RAM::receiveTransfer(std::string path, uint32_t origin, uint32_t size, uint32_t destination) {
     ifstream file (path, ios::in|ios::binary|ios::ate);
     if (!file.is_open()) {
-        printError("Unable to load binary");
+        cout << "Unable to load binary" << endl;
     }
     file.seekg(origin);
     uint8_t *dataDestination = &data[destination];

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -41,7 +41,8 @@ Renderer::Renderer(std::unique_ptr<Window> &mainWindow) : logger(LogLevel::NoLog
 
     Dimensions screenDimensions = mainWindow->getDimensions();
     screenTexture = make_unique<Texture>(((GLsizei) screenDimensions.width), ((GLsizei) screenDimensions.height));
-    checkForOpenGLErrors();
+    RendererDebugger *rendererDebugger = RendererDebugger::getInstance();
+    rendererDebugger->checkForOpenGLErrors();
 }
 
 Renderer::~Renderer() {
@@ -103,7 +104,8 @@ void Renderer::prepareFrame() {
 void Renderer::renderFrame() {
     Framebuffer framebuffer = Framebuffer(screenTexture);
     buffer->draw(mode);
-    checkForOpenGLErrors();
+    RendererDebugger *rendererDebugger = RendererDebugger::getInstance();
+    rendererDebugger->checkForOpenGLErrors();
 }
 
 void Renderer::finalizeFrame(GPU *gpu) {
@@ -129,7 +131,8 @@ void Renderer::finalizeFrame(GPU *gpu) {
     }
     screenBuffer->addData(pixels);
     screenBuffer->draw(GL_TRIANGLE_STRIP);
-    checkForOpenGLErrors();
+    RendererDebugger *rendererDebugger = RendererDebugger::getInstance();
+    rendererDebugger->checkForOpenGLErrors();
 }
 
 void Renderer::setDrawingOffset(int16_t x, int16_t y) {
@@ -147,5 +150,6 @@ void Renderer::loadImage(std::unique_ptr<GPUImageBuffer> &imageBuffer) {
     textureBuffer->addData(data);
     Framebuffer framebuffer = Framebuffer(screenTexture);
     textureBuffer->draw(GL_TRIANGLE_STRIP);
-    checkForOpenGLErrors();
+    RendererDebugger *rendererDebugger = RendererDebugger::getInstance();
+    rendererDebugger->checkForOpenGLErrors();
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -4,7 +4,6 @@
 #include <streambuf>
 #include <vector>
 #include "RendererDebugger.hpp"
-#include "Output.hpp"
 #include "Framebuffer.hpp"
 #include "GPU.hpp"
 #include "ConfigurationManager.hpp"
@@ -66,7 +65,7 @@ void Renderer::checkForceDraw(uint verticesToRender, GLenum newMode) {
 void Renderer::pushLine(std::vector<Vertex> vertices) {
     uint size = vertices.size();
     if (size < 2) {
-        logger.logError(format("Unhandled line with %d vertices", size));
+        logger.logError("Unhandled line with %d vertices", size);
         return;
     }
     checkForceDraw(size, GL_LINES);
@@ -78,7 +77,7 @@ void Renderer::pushLine(std::vector<Vertex> vertices) {
 void Renderer::pushPolygon(std::vector<Vertex> vertices) {
     uint size = vertices.size();
     if (size < 3 || size > 4) {
-        logger.logError(format("Unhandled polygon with %d vertices", size));
+        logger.logError("Unhandled polygon with %d vertices", size);
         return;
     }
     checkForceDraw(size, GL_TRIANGLES);

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -11,7 +11,7 @@
 
 using namespace std;
 
-Renderer::Renderer(std::unique_ptr<Window> &mainWindow) : mode(GL_TRIANGLES) {
+Renderer::Renderer(std::unique_ptr<Window> &mainWindow) : logger(LogLevel::NoLog), mode(GL_TRIANGLES) {
     ConfigurationManager *configurationManager = ConfigurationManager::getInstance();
     resizeToFitFramebuffer = configurationManager->shouldResizeWindowToFitFramebuffer();
 
@@ -65,7 +65,7 @@ void Renderer::checkForceDraw(uint verticesToRender, GLenum newMode) {
 void Renderer::pushLine(std::vector<Vertex> vertices) {
     uint size = vertices.size();
     if (size < 2) {
-        printError("Unhandled line with %d vertices", size);
+        logger.logError(format("Unhandled line with %d vertices", size));
         return;
     }
     checkForceDraw(size, GL_LINES);
@@ -77,7 +77,7 @@ void Renderer::pushLine(std::vector<Vertex> vertices) {
 void Renderer::pushPolygon(std::vector<Vertex> vertices) {
     uint size = vertices.size();
     if (size < 3 || size > 4) {
-        printError("Unhandled polygon with %d vertices", size);
+        logger.logError(format("Unhandled polygon with %d vertices", size));
         return;
     }
     checkForceDraw(size, GL_TRIANGLES);

--- a/src/RendererBuffer.cpp
+++ b/src/RendererBuffer.cpp
@@ -50,7 +50,8 @@ void RendererBuffer<T>::draw(GLenum mode) {
         }
     }
     clean();
-    checkForOpenGLErrors();
+    RendererDebugger *rendererDebugger = RendererDebugger::getInstance();
+    rendererDebugger->checkForOpenGLErrors();
 }
 
 template <class T>

--- a/src/RendererBuffer.cpp
+++ b/src/RendererBuffer.cpp
@@ -2,7 +2,6 @@
 #include <stddef.h>
 #include "Vertex.hpp"
 #include "RendererDebugger.hpp"
-#include "Output.hpp"
 
 using namespace std;
 

--- a/src/RendererDebugger.cpp
+++ b/src/RendererDebugger.cpp
@@ -2,7 +2,6 @@
 #include <glad/glad.h>
 #include <vector>
 #include <string>
-#include "Output.hpp"
 #include <sstream>
 #include "ConfigurationManager.hpp"
 

--- a/src/RendererDebugger.cpp
+++ b/src/RendererDebugger.cpp
@@ -37,7 +37,7 @@ string debugSourceDescription(DebugSource source) {
             return "Other";
         }
         default: {
-            printError("Invalid source");
+            // printError("Invalid source");
             return "";
         }
     }
@@ -73,7 +73,7 @@ string debugTypeDescription(DebugType type) {
             return "Other";
         }
         default: {
-            printError("Invalid type");
+            // printError("Invalid type");
             return "";
         }
     }
@@ -101,7 +101,7 @@ string debugSeverityDescription(DebugSeverity severity) {
             return "Notification";
         }
         default: {
-            printError("Invalid severity");
+            // printError("Invalid severity");
             return "";
         }
     }
@@ -132,12 +132,12 @@ void checkForOpenGLErrors() {
              << "|" << debugTypeDescription(debugType)
              << "|0x" << hex << id << "|"
              << message;
-        printWarning(stream.str().c_str());
+        // printWarning(stream.str().c_str());
         if (debugSeverity == DebugSeverity::High) {
             highSeverityFound = true;
         }
     }
     if (highSeverityFound) {
-        printError("Encountered high severity OpenGL error");
+        // printError("Encountered high severity OpenGL error");
     }
 }

--- a/src/RendererProgram.cpp
+++ b/src/RendererProgram.cpp
@@ -41,7 +41,8 @@ GLuint RendererProgram::compileShader(string filePath, GLenum shaderType) const 
     GLint status = GL_FALSE;
     glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
     if (status == GL_FALSE) {
-        checkForOpenGLErrors();
+        RendererDebugger *rendererDebugger = RendererDebugger::getInstance();
+        rendererDebugger->checkForOpenGLErrors();
     }
     return shader;
 }
@@ -55,7 +56,8 @@ GLuint RendererProgram::linkProgram(vector<GLuint> shaders) const {
     GLint status = GL_FALSE;
     glGetProgramiv(program, GL_LINK_STATUS, &status);
     if (status == GL_FALSE) {
-        checkForOpenGLErrors();
+        RendererDebugger *rendererDebugger = RendererDebugger::getInstance();
+        rendererDebugger->checkForOpenGLErrors();
     }
     return program;
 }
@@ -63,6 +65,7 @@ GLuint RendererProgram::linkProgram(vector<GLuint> shaders) const {
 GLuint RendererProgram::findProgramAttribute(string attribute) const {
     const GLchar *attrib = attribute.c_str();
     GLint index = glGetAttribLocation(program, attrib);
-    checkForOpenGLErrors();
+    RendererDebugger *rendererDebugger = RendererDebugger::getInstance();
+    rendererDebugger->checkForOpenGLErrors();
     return index;
 }

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -1,6 +1,7 @@
 #include "Texture.hpp"
 #include "RendererDebugger.hpp"
 #include "Output.hpp"
+#include <iostream>
 
 using namespace std;
 
@@ -33,7 +34,8 @@ void Texture::bind(GLenum texture) {
 
 void Texture::setImageFromBuffer(std::unique_ptr<GPUImageBuffer> &imageBuffer) {
     if (!imageBuffer->isValid()) {
-        printError("Invalid image buffer");
+        cout << "Invalid image buffer" << endl;
+        exit(1);
     }
     uint16_t x, y, width, height;
     tie(x, y) = imageBuffer->destination();

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-Texture::Texture(GLsizei width, GLsizei height) : width(width), height(height) {
+Texture::Texture(GLsizei width, GLsizei height) : logger(LogLevel::NoLog), width(width), height(height) {
     glGenTextures(1, &object);
     glBindTexture(GL_TEXTURE_2D, object);
     glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGB5_A1, width, height);
@@ -33,8 +33,7 @@ void Texture::bind(GLenum texture) {
 
 void Texture::setImageFromBuffer(std::unique_ptr<GPUImageBuffer> &imageBuffer) {
     if (!imageBuffer->isValid()) {
-        cout << "Invalid image buffer" << endl;
-        exit(1);
+        logger.logError("Invalid image buffer");
     }
     uint16_t x, y, width, height;
     tie(x, y) = imageBuffer->destination();

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -1,6 +1,5 @@
 #include "Texture.hpp"
 #include "RendererDebugger.hpp"
-#include "Output.hpp"
 #include <iostream>
 
 using namespace std;

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -43,5 +43,6 @@ void Texture::setImageFromBuffer(std::unique_ptr<GPUImageBuffer> &imageBuffer) {
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glBindTexture(GL_TEXTURE_2D, object);
     glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, width, height, GL_RGBA, GL_UNSIGNED_SHORT_1_5_5_5_REV, imageBuffer->bufferRef());
-    checkForOpenGLErrors();
+    RendererDebugger *rendererDebugger = RendererDebugger::getInstance();
+    rendererDebugger->checkForOpenGLErrors();
 }

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -2,7 +2,7 @@
 #include "Constants.h"
 #include "Output.hpp"
 
-Timer::Timer(uint8_t identity) : identity(identity), counterValue(), counterMode(), counterTarget(), counter() {}
+Timer::Timer(uint8_t identity) : logger(LogLevel::NoLog), identity(identity), counterValue(), counterMode(), counterTarget(), counter() {}
 
 Timer::~Timer() {}
 
@@ -118,5 +118,5 @@ void Timer::checkTargetsAndOverflows() {
 }
 
 void Timer::checkInterruptRequest() {
-    printWarning("Unhandled interrupt trigger for timer %d", identity);
+    logger.logWarning(format("Unhandled interrupt trigger for timer %d", identity));
 }

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -1,6 +1,5 @@
 #include "Timer.hpp"
 #include "Constants.h"
-#include "Output.hpp"
 
 Timer::Timer(uint8_t identity) : logger(LogLevel::NoLog), identity(identity), counterValue(), counterMode(), counterTarget(), counter() {}
 
@@ -118,5 +117,5 @@ void Timer::checkTargetsAndOverflows() {
 }
 
 void Timer::checkInterruptRequest() {
-    logger.logWarning(format("Unhandled interrupt trigger for timer %d", identity));
+    logger.logWarning("Unhandled interrupt trigger for timer %d", identity);
 }

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1,9 +1,9 @@
 #include "Window.hpp"
-#include "Logger.hpp"
+#include "ConfigurationManager.hpp"
 
 using namespace std;
 
-Window::Window(bool mainWindow, string title, uint32_t width, uint32_t height) : mainWindow(mainWindow), title(title), width(width), height(height), hidden(false) {
+Window::Window(bool mainWindow, string title, uint32_t width, uint32_t height) : logger(LogLevel::NoLog), mainWindow(mainWindow), title(title), width(width), height(height), hidden(false) {
     window = SDL_CreateWindow(title.c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, SDL_WINDOW_OPENGL);
     windowID = SDL_GetWindowID(window);
     glContext = SDL_GL_CreateContext(window);
@@ -41,8 +41,7 @@ void Window::handleSDLEvent(SDL_Event event) {
                 SDL_HideWindow(window);
             }
             if (mainWindow) {
-                Logger *logger = Logger::getInstance();
-                logger->flush();
+                logger.flush();
             }
             break;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,9 +20,6 @@ int main(int argc, char* argv[]) {
     emulatorRunner->setEmulator(emulator.get());
     Debugger *debugger = Debugger::getInstance();
     debugger->setCPU(emulator->getCPU());
-    Logger *logger = Logger::getInstance();
-    logger->configure(configurationManager->shouldTraceLogs(), configurationManager->shouldLogVerbose());
-    logger->setupTraceFile();
     bool quit = false;
     uint32_t initTicks = SDL_GetTicks();
     float interval = 1000;


### PR DESCRIPTION
[Hello darkness, my old friend](https://github.com/UnsafePointer/ruby/pull/8).

Logs can now be configured by device and/or severity. Configuration file looks like this: 

```yaml
debugInfoWindow: false
showFramebuffer: false
log: # WAR, MSG, NOLOG
  bios: MSG
  cdrom: MSG
  interconnect: NOLOG
  cpu: NOLOG
  gpu: NOLOG
  opengl: NOLOG
  trace: true # to file
```