### PR TITLE
Implement DMA interrupts

### DIFF
--- a/include/DMA.hpp
+++ b/include/DMA.hpp
@@ -107,7 +107,7 @@ union DMAInterrupt {
     DMAInterrupt() : value(0) {}
 
     IRQEnable IRQEnableStatus() const { return IRQEnable(_IRQEnable); }
-    IRQFlags IRQFlagsStatus() const { return IRQFlags(_IRQEnable); }
+    IRQFlags IRQFlagsStatus() const { return IRQFlags(_IRQFlags); }
 };
 
 // DMA Register Summary

--- a/src/BIOS.cpp
+++ b/src/BIOS.cpp
@@ -1041,8 +1041,19 @@ optional<string> BIOS::checkFunctions(uint32_t programCounter, uint32_t r9, arra
     string functionCallLog = (*result);
     bool functionCallLogIsRFE = functionCallLog.find("ReturnFromException()") == 0;
     if (functionCallLogIsRFE) {
+        logger.logMessage(functionCallLog.c_str());
         return result;
     }
-    logger.logMessage(functionCallLog.c_str());
+    bool functionCallLogIsTestEvent = functionCallLog.find("TestEvent") == 0;
+    if (functionCallLogIsTestEvent) {
+        logger.logMessage(functionCallLog.c_str());
+        return result;
+    }
+    bool functionCallLogIsPutChat = functionCallLog.find("std_out_putchar") == 0;
+    if (functionCallLogIsPutChat) {
+        logger.logMessage(functionCallLog.c_str());
+        return result;
+    }
+    logger.logWarning(functionCallLog.c_str());
     return result;
 }

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -35,7 +35,7 @@ Emulator::Emulator() : logger(LogLevel::NoLog), ttyBuffer(), biosFunctionsLog() 
     interruptController = make_unique<InterruptController>(cop0);
     LogLevel cdromLogLevel = configurationManager->cdromLogLevel();
     cdrom = make_unique<CDROM>(cdromLogLevel, interruptController);
-    dma = make_unique<DMA>(configurationManager->dmaLogLevel(), ram, gpu, cdrom);
+    dma = make_unique<DMA>(configurationManager->dmaLogLevel(), ram, gpu, cdrom, interruptController);
     expansion1 = make_unique<Expansion1>();
     timer0 = make_unique<Timer0>();
     timer1 = make_unique<Timer1>();
@@ -66,6 +66,7 @@ void Emulator::emulateFrame() {
             }
             totalSystemClocksThisFrame++;
         }
+        dma->step();
         cdrom->step();
         timer0->step(systemClockStep);
         timer1->step(systemClockStep);


### PR DESCRIPTION
Currently the emulator gets stuck after the `CdInitSubFunc()` BIOS function. Thanks to #23, it's easy to identify what's missing:

```
BIOS: CdInitSubFunc()
DMA: DPCR [W]: 0x9099
DMA: DICR [R]: 0x8c0000
DMA: DICR [W]: 0x888c0000
BIOS: CdAsyncSeekL(src) args: 801ffd78
```

`DICR` write is possibly trying to acknowledge a DMA interrupt that never happened. After the changes in this pull request the emulators gets a bit further, up to the bootstrap loader to be precise (trying to load `SYSTEM.CNF`).

```
BOOTSTRAP LOADER Type C Ver 2.1   03-JUL-1994
Copyright 1993,1994 (C) Sony Computer Entertainment Inc.
BIOS: FileOpen(filename,accessmode) args: 801ffe98, 1
BIOS: strcmp(str1,str2) args: bfc0e3a0, 801ffd9c
BIOS: strcmp(str1,str2) args: bfc0e340, 801ffd9c
``` 

<details><summary>Full log:</summary>
<p>

```
DMA: DPCR [W]: 0x9099
DMA: DICR [R]: 0x88c0000
DMA: DICR [W]: 0x888c0000
BIOS: CdAsyncSeekL(src) args: 801ffd78
BIOS: UnDeliverEvent(class,spec) args: f0000003, 20
BIOS: UnDeliverEvent(class,spec) args: f0000003, 80
BIOS: UnDeliverEvent(class,spec) args: f0000003, 8000
BIOS: UnDeliverEvent(class,spec) args: f0000003, 100
BIOS: UnDeliverEvent(class,spec) args: f0000003, 200
BIOS: DeliverEvent(class, spec) args: f0000003, 20
BIOS: CdAsyncReadSector(count,dst,mode) args: 1, a000b070, 80
BIOS: UnDeliverEvent(class,spec) args: f0000003, 40
BIOS: UnDeliverEvent(class,spec) args: f0000003, 10
BIOS: UnDeliverEvent(class,spec) args: f0000003, 20
BIOS: UnDeliverEvent(class,spec) args: f0000003, 80
BIOS: UnDeliverEvent(class,spec) args: f0000003, 8000
BIOS: UnDeliverEvent(class,spec) args: f0000003, 100
BIOS: UnDeliverEvent(class,spec) args: f0000003, 200
DMA: DICR [R]: 0x8c0000
DMA: DICR [W]: 0x8c0000
DMA: DPCR [R]: 0x9099
DMA: DPCR [W]: 0x9099
DMA: D3_MADR [W]: 0xa000b070
DMA: D3_BCR [W]: 0x10200
DMA: D3_CHCR [W]: 0x11000000
DMA: D3_MADR [R]: 0xb070
DMA: Block for port: CDROM with base address: 0xb070 and transfer size: 0xffffd6c8
DMA: DICR [R]: 0x88c0000
DMA: DICR [W]: 0x888c0000
BIOS: DeliverEvent(class, spec) args: f0000003, 10
BIOS: DeliverEvent(class, spec) args: f0000003, 20
BIOS: CdAsyncSeekL(src) args: 801ffd78
BIOS: UnDeliverEvent(class,spec) args: f0000003, 20
BIOS: UnDeliverEvent(class,spec) args: f0000003, 80
BIOS: UnDeliverEvent(class,spec) args: f0000003, 8000
BIOS: UnDeliverEvent(class,spec) args: f0000003, 100
BIOS: UnDeliverEvent(class,spec) args: f0000003, 200
BIOS: DeliverEvent(class, spec) args: f0000003, 20
BIOS: CdAsyncReadSector(count,dst,mode) args: 1, a000b070, 80
BIOS: UnDeliverEvent(class,spec) args: f0000003, 40
BIOS: UnDeliverEvent(class,spec) args: f0000003, 10
BIOS: UnDeliverEvent(class,spec) args: f0000003, 20
BIOS: UnDeliverEvent(class,spec) args: f0000003, 80
BIOS: UnDeliverEvent(class,spec) args: f0000003, 8000
BIOS: UnDeliverEvent(class,spec) args: f0000003, 100
BIOS: UnDeliverEvent(class,spec) args: f0000003, 200
DMA: DICR [R]: 0x8c0000
DMA: DICR [W]: 0x8c0000
DMA: DPCR [R]: 0x9099
DMA: DPCR [W]: 0x9099
DMA: D3_MADR [W]: 0xa000b070
DMA: D3_BCR [W]: 0x10200
DMA: D3_CHCR [W]: 0x11000000
DMA: D3_MADR [R]: 0xb070
DMA: Block for port: CDROM with base address: 0xb070 and transfer size: 0xffffd6c8
DMA: DICR [R]: 0x88c0000
DMA: DICR [W]: 0x888c0000
BIOS: DeliverEvent(class, spec) args: f0000003, 10
BIOS: DeliverEvent(class, spec) args: f0000003, 20

BOOTSTRAP LOADER Type C Ver 2.1   03-JUL-1994
Copyright 1993,1994 (C) Sony Computer Entertainment Inc.
BIOS: FileOpen(filename,accessmode) args: 801ffe98, 1
BIOS: strcmp(str1,str2) args: bfc0e3a0, 801ffd9c
BIOS: strcmp(str1,str2) args: bfc0e340, 801ffd9c
BIOS: CdAsyncGetStatus(dst) args: 801ffd6c
BIOS: UnDeliverEvent(class,spec) args: f0000003, 40
BIOS: UnDeliverEvent(class,spec) args: f0000003, 10
BIOS: UnDeliverEvent(class,spec) args: f0000003, 20
BIOS: UnDeliverEvent(class,spec) args: f0000003, 80
BIOS: UnDeliverEvent(class,spec) args: f0000003, 8000
BIOS: UnDeliverEvent(class,spec) args: f0000003, 100
BIOS: UnDeliverEvent(class,spec) args: f0000003, 200
BIOS: DeliverEvent(class, spec) args: f0000003, 20
BIOS: CdAsyncSeekL(src) args: 801ffc98
BIOS: UnDeliverEvent(class,spec) args: f0000003, 20
BIOS: UnDeliverEvent(class,spec) args: f0000003, 80
BIOS: UnDeliverEvent(class,spec) args: f0000003, 8000
BIOS: UnDeliverEvent(class,spec) args: f0000003, 100
BIOS: UnDeliverEvent(class,spec) args: f0000003, 200
BIOS: DeliverEvent(class, spec) args: f0000003, 200
```

</p>
</details>
