### PR TITLE
Add SPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ruby (ルビィ) is a [PlayStation](https://en.wikipedia.org/wiki/PlayStation_(c
 - [x] Timers
 - [x] Controllers and Memory Cards
 - [ ] GTE
-- [ ] SPU
+- [x] SPU
 - [ ] SIO
 - [ ] PIO
 

--- a/include/ConfigurationManager.hpp
+++ b/include/ConfigurationManager.hpp
@@ -18,6 +18,7 @@ class ConfigurationManager {
     LogLevel gpu;
     LogLevel opengl;
     LogLevel dma;
+    LogLevel spu;
     bool trace;
 
     ConfigurationManager();
@@ -37,5 +38,6 @@ public:
     LogLevel gpuLogLevel();
     LogLevel openGLLogLevel();
     LogLevel dmaLogLevel();
+    LogLevel spuLogLevel();
     bool shouldTraceLogs();
 };

--- a/include/DMA.hpp
+++ b/include/DMA.hpp
@@ -75,7 +75,7 @@ union IRQEnable {
                 return GPUIRQEnable > 0;
             case CDROMP:
                 return CDROMIRQEnable > 0;
-            case SPU:
+            case SPUP:
                 return SPUIRQEnable > 0;
             case PIO:
                 return PIOIRQEnable > 0;
@@ -115,7 +115,7 @@ union IRQFlags {
             case CDROMP:
                 CDROMIRQFlags = 1;
                 break;
-            case SPU:
+            case SPUP:
                 SPUIRQFlags = 1;
                 break;
             case PIO:

--- a/include/DMAPort.hpp
+++ b/include/DMAPort.hpp
@@ -6,7 +6,7 @@ enum DMAPort : uint8_t {
     MDECout = 1,
     GPUP = 2,
     CDROMP = 3,
-    SPU = 4,
+    SPUP = 4,
     PIO = 5,
     OTC = 6,
     None = 7

--- a/include/Emulator.hpp
+++ b/include/Emulator.hpp
@@ -19,6 +19,7 @@
 #include "Controller.hpp"
 #include <string>
 #include "Logger.hpp"
+#include "SPU.hpp"
 
 class Emulator {
     Logger logger;
@@ -42,6 +43,7 @@ class Emulator {
     std::unique_ptr<Timer1> timer1;
     std::unique_ptr<Timer2> timer2;
     std::unique_ptr<Controller> controller;
+    std::unique_ptr<SPU> spu;
 
     std::string ttyBuffer;
     std::vector<std::string> biosFunctionsLog;

--- a/include/Interconnect.hpp
+++ b/include/Interconnect.hpp
@@ -14,6 +14,7 @@
 #include "Timer.hpp"
 #include "Controller.hpp"
 #include "Logger.hpp"
+#include "SPU.hpp"
 
 const Range ramRange = Range(0x00000000, RAM_SIZE);
 const Range scratchpadRange = Range(0x1f800000, SCRATCHPAD_SIZE);
@@ -62,9 +63,10 @@ class Interconnect {
     std::unique_ptr<Timer1> &timer1;
     std::unique_ptr<Timer2> &timer2;
     std::unique_ptr<Controller> &controller;
+    std::unique_ptr<SPU> &spu;
     uint32_t maskRegion(uint32_t address) const;
 public:
-    Interconnect(LogLevel logLevel, std::unique_ptr<COP0> &cop0, std::unique_ptr<BIOS> &bios, std::unique_ptr<RAM> &ram, std::unique_ptr<GPU> &gpu, std::unique_ptr<DMA> &dma, std::unique_ptr<Scratchpad> &scratchpad, std::unique_ptr<CDROM> &cdrom, std::unique_ptr<InterruptController> &interruptController, std::unique_ptr<Expansion1> &expansion1, std::unique_ptr<Timer0> &timer0, std::unique_ptr<Timer1> &timer1, std::unique_ptr<Timer2> &timer2, std::unique_ptr<Controller> &controller);
+    Interconnect(LogLevel logLevel, std::unique_ptr<COP0> &cop0, std::unique_ptr<BIOS> &bios, std::unique_ptr<RAM> &ram, std::unique_ptr<GPU> &gpu, std::unique_ptr<DMA> &dma, std::unique_ptr<Scratchpad> &scratchpad, std::unique_ptr<CDROM> &cdrom, std::unique_ptr<InterruptController> &interruptController, std::unique_ptr<Expansion1> &expansion1, std::unique_ptr<Timer0> &timer0, std::unique_ptr<Timer1> &timer1, std::unique_ptr<Timer2> &timer2, std::unique_ptr<Controller> &controller, std::unique_ptr<SPU> &spu);
     ~Interconnect();
 
     template <typename T>

--- a/include/Interconnect.tcc
+++ b/include/Interconnect.tcc
@@ -75,6 +75,11 @@ inline T Interconnect::load(uint32_t address) const {
         logger.logWarning("Unhandled Memory Control read at offset: %#x", *offset);
         return 0;
     }
+    offset = ramSizeRange.contains(absoluteAddress);
+    if (offset) {
+        logger.logWarning("Unhandled RAM Control read at offset: %#x", *offset);
+        return 0;
+    }
     Debugger *debugger = Debugger::getInstance();
     if (debugger->isAttached()) {
         return 0;

--- a/include/Interconnect.tcc
+++ b/include/Interconnect.tcc
@@ -11,6 +11,7 @@
 #include "Expansion1.tcc"
 #include "Timer.tcc"
 #include "Controller.tcc"
+#include "SPU.tcc"
 
 template <typename T>
 inline T Interconnect::load(uint32_t address) const {
@@ -55,8 +56,7 @@ inline T Interconnect::load(uint32_t address) const {
     }
     offset = soundProcessingUnitRange.contains(absoluteAddress);
     if (offset) {
-        logger.logMessage("Unhandled Sound Processing Unit read at offset: %#x", *offset);
-        return 0;
+        return spu->load<T>(*offset);
     }
     offset = scratchpadRange.contains(absoluteAddress);
     if (offset) {
@@ -160,7 +160,7 @@ inline void Interconnect::store(uint32_t address, T value) const {
     }
     offset = soundProcessingUnitRange.contains(absoluteAddress);
     if (offset) {
-        logger.logMessage("Unhandled Sound Processing Unit write at offset: %#x", *offset);
+        spu->store<T>(*offset, value);
         return;
     }
     offset = expansion2Range.contains(absoluteAddress);

--- a/include/Interconnect.tcc
+++ b/include/Interconnect.tcc
@@ -70,6 +70,11 @@ inline T Interconnect::load(uint32_t address) const {
     if (offset) {
         return controller->load<T>(*offset);
     }
+    offset = memoryControlRange.contains(absoluteAddress);
+    if (offset) {
+        logger.logWarning("Unhandled Memory Control read at offset: %#x", *offset);
+        return 0;
+    }
     Debugger *debugger = Debugger::getInstance();
     if (debugger->isAttached()) {
         return 0;

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -168,6 +168,20 @@ struct SPUReverbMode {
     }
 };
 
+// 1F801DB0h - CD Audio Input Volume (for normal CD-DA, and compressed XA-ADPCM)
+// 0-15  Volume Left   (-8000h..+7FFFh)
+// 16-31 Volume Right  (-8000h..+7FFFh)
+union SPUCDAudioInputVolume {
+    struct {
+        uint32_t left : 16;
+        uint32_t right : 16;
+    };
+
+    uint32_t value;
+
+    SPUCDAudioInputVolume() : value() {}
+};
+
 class SPU {
     Logger logger;
 
@@ -177,6 +191,7 @@ class SPU {
     SPUPitchModulationEnableFlags pitchModulationEnableFlags;
     SPUNoiseModeEnable noiseModeEnable;
     SPUReverbMode reverbMode;
+    SPUCDAudioInputVolume CDAudioInputVolume;
 
     uint16_t controlRegister() const;
     void setControlRegister(uint16_t value);
@@ -188,6 +203,10 @@ class SPU {
     uint32_t noiseModeEnableRegister() const;
     void setReverbModeRegister(uint32_t value);
     uint32_t reverbModeRegister() const;
+    void setCDAudioInputVolumeLeft(uint16_t value);
+    uint16_t CDAudioInputVolumeLeft() const;
+    void setCDAudioInputVolumeRight(uint16_t value);
+    uint16_t CDAudioInputVolumeRight() const;
 public:
     SPU(LogLevel logLevel);
     ~SPU();

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+class SPU {
+
+public:
+    SPU();
+    ~SPU();
+};

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -1,10 +1,11 @@
 #pragma once
 #include <cstdint>
+#include "Logger.hpp"
 
 class SPU {
-
+    Logger logger;
 public:
-    SPU();
+    SPU(LogLevel logLevel);
     ~SPU();
 
     template <typename T>

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -2,8 +2,54 @@
 #include <cstdint>
 #include "Logger.hpp"
 
+enum SPUControlRAMTransferMode {
+    Stop = 0,
+    ManualWrite = 1,
+    DMAWrite = 2,
+    DMARead = 3,
+};
+
+// 1F801DAAh - SPU Control Register (SPUCNT)
+// 15    SPU Enable              (0=Off, 1=On)       (Don't care for CD Audio)
+// 14    Mute SPU                (0=Mute, 1=Unmute)  (Don't care for CD Audio)
+// 13-10 Noise Frequency Shift   (0..0Fh = Low .. High Frequency)
+// 9-8   Noise Frequency Step    (0..03h = Step "4,5,6,7")
+// 7     Reverb Master Enable    (0=Disabled, 1=Enabled)
+// 6     IRQ9 Enable (0=Disabled/Acknowledge, 1=Enabled; only when Bit15=1)
+// 5-4   Sound RAM Transfer Mode (0=Stop, 1=ManualWrite, 2=DMAwrite, 3=DMAread)
+// 3     External Audio Reverb   (0=Off, 1=On)
+// 2     CD Audio Reverb         (0=Off, 1=On) (for CD-DA and XA-ADPCM)
+// 1     External Audio Enable   (0=Off, 1=On)
+// 0     CD Audio Enable         (0=Off, 1=On) (for CD-DA and XA-ADPCM)
+union SPUControl {
+    struct {
+       uint16_t CDAudioEnable : 1;
+       uint16_t externalAudioEnable : 1;
+       uint16_t CDAudioReverb : 1;
+       uint16_t externalAudioReverb : 1;
+       uint16_t _RAMTransferMode : 2;
+       uint16_t IRQEnable : 1;
+       uint16_t reverbMasterEnable : 1;
+       uint16_t noiseFrequencyStep : 2;
+       uint16_t noiseFrequencyShift : 4;
+       uint16_t mute : 1;
+       uint16_t enable : 1;
+    };
+
+    uint16_t value;
+
+    SPUControl() : value() {}
+
+    SPUControlRAMTransferMode RAMTransferMode() { return SPUControlRAMTransferMode(_RAMTransferMode); }
+};
+
 class SPU {
     Logger logger;
+
+    SPUControl control;
+
+    uint16_t controlRegister() const;
+    void setControlRegister(uint16_t value);
 public:
     SPU(LogLevel logLevel);
     ~SPU();

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -1,8 +1,14 @@
 #pragma once
+#include <cstdint>
 
 class SPU {
 
 public:
     SPU();
     ~SPU();
+
+    template <typename T>
+    inline T load(uint32_t offset) const;
+    template <typename T>
+    inline void store(uint32_t offset, T value);
 };

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -146,6 +146,28 @@ struct SPUNoiseModeEnable {
     }
 };
 
+enum SPUReverbModeValue {
+    ToMixer = 0,
+    ToMixerAndToReverb = 1,
+};
+
+// 1F801D98h - Voice 0..23 Reverb mode aka Echo On (EON) (R/W)
+// 0-23  Voice 0..23 Destination (0=To Mixer, 1=To Mixer and to Reverb)
+// 24-31 Not used
+struct SPUReverbMode {
+    uint32_t value;
+
+    SPUReverbMode() : value() {}
+
+    SPUReverbModeValue reverbModeValueAtIndex(uint8_t voiceIndex) {
+        if (voiceIndex >= 24) {
+            std::cout << format("Unsupported index %d for KOFF SPU register", voiceIndex) << std::endl;
+            exit(1);
+        }
+        return SPUReverbModeValue((value >> voiceIndex) & 0x1);
+    }
+};
+
 class SPU {
     Logger logger;
 
@@ -154,6 +176,7 @@ class SPU {
     SPUVoiceKeyOff voiceKeyOff;
     SPUPitchModulationEnableFlags pitchModulationEnableFlags;
     SPUNoiseModeEnable noiseModeEnable;
+    SPUReverbMode reverbMode;
 
     uint16_t controlRegister() const;
     void setControlRegister(uint16_t value);
@@ -163,6 +186,8 @@ class SPU {
     uint32_t pitchModulationEnableFlagsRegister() const;
     void setNoiseModeEnableRegister(uint32_t value);
     uint32_t noiseModeEnableRegister() const;
+    void setReverbModeRegister(uint32_t value);
+    uint32_t reverbModeRegister() const;
 public:
     SPU(LogLevel logLevel);
     ~SPU();

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -168,6 +168,29 @@ struct SPUNoiseModeEnable {
     }
 };
 
+enum SPUVoiceStatusValue {
+    NewlyKeyedOn = 0,
+    ReachedLoopEnd = 1,
+};
+
+// 1F801D9Ch - Voice 0..23 ON/OFF (status) (ENDX) (R)
+// 0-23  Voice 0..23 Status (0=Newly Keyed On, 1=Reached LOOP-END)
+// 24-31 Not used
+struct SPUVoiceStatus {
+    uint32_t value;
+
+    SPUVoiceStatus() : value() {}
+
+    SPUVoiceStatusValue noiseModeEnableValueAtIndex(uint8_t voiceIndex) {
+        if (voiceIndex >= 24) {
+            std::cout << format("Unsupported index %d for ENDX SPU register", voiceIndex) << std::endl;
+            exit(1);
+        }
+        return SPUVoiceStatusValue((value >> voiceIndex) & 0x1);
+    }
+};
+
+
 enum SPUReverbModeValue {
     ToMixer = 0,
     ToMixerAndToReverb = 1,
@@ -308,6 +331,7 @@ class SPU {
     SPURAMDataTransferAddress RAMDataTransferAddress;
     SPUVoiceKeyOn voiceKeyOn;
     SPUCurrentMainVolume currentMainVolume;
+    SPUVoiceStatus voiceStatus;
 
     uint16_t controlRegister() const;
     void setControlRegister(uint16_t value);
@@ -336,6 +360,8 @@ class SPU {
     uint16_t currentMainVolumeLeft() const;
     void setCurrentMainVolumeRight(uint16_t value);
     uint16_t currentMainVolumeRight() const;
+    uint32_t voiceStatusRegister() const;
+    void setVoiceStatusRegister(uint32_t value);
 public:
     SPU(LogLevel logLevel);
     ~SPU();

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -313,6 +313,7 @@ class SPU {
     void setExternalAudioInputVolumeRight(uint16_t value);
     uint16_t externalAudioInputVolumeRight() const;
     void setRAMDataTransferControlRegister(uint16_t value);
+    uint16_t RAMDataTransferControlRegister() const;
     void setRAMDataTransferAddressRegister(uint16_t value);
     uint32_t voiceKeyOnRegister() const;
     void setVoiceKeyOnRegister(uint32_t value);

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -124,6 +124,28 @@ struct SPUPitchModulationEnableFlags {
     }
 };
 
+enum SPUNoiseModeEnableValue {
+    ADPCM = 0,
+    Noise = 1,
+};
+
+// 1F801D94h - Voice 0..23 Noise mode enable (NON)
+// 0-23  Voice 0..23 Noise (0=ADPCM, 1=Noise)
+// 24-31 Not used
+struct SPUNoiseModeEnable {
+    uint32_t value;
+
+    SPUNoiseModeEnable() : value() {}
+
+    SPUNoiseModeEnableValue noiseModeEnableValueAtIndex(uint8_t voiceIndex) {
+        if (voiceIndex >= 24) {
+            std::cout << format("Unsupported index %d for KOFF SPU register", voiceIndex) << std::endl;
+            exit(1);
+        }
+        return SPUNoiseModeEnableValue((value >> voiceIndex) & 0x1);
+    }
+};
+
 class SPU {
     Logger logger;
 
@@ -131,6 +153,7 @@ class SPU {
     SPUStatus status;
     SPUVoiceKeyOff voiceKeyOff;
     SPUPitchModulationEnableFlags pitchModulationEnableFlags;
+    SPUNoiseModeEnable noiseModeEnable;
 
     uint16_t controlRegister() const;
     void setControlRegister(uint16_t value);
@@ -138,6 +161,8 @@ class SPU {
     void setVoiceKeyOffRegister(uint32_t value);
     void setPitchModulationEnableFlagsRegister(uint32_t value);
     uint32_t pitchModulationEnableFlagsRegister() const;
+    void setNoiseModeEnableRegister(uint32_t value);
+    uint32_t noiseModeEnableRegister() const;
 public:
     SPU(LogLevel logLevel);
     ~SPU();

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -218,6 +218,20 @@ union SPUExternalAudoInputVolume {
     SPUExternalAudoInputVolume() : value() {}
 };
 
+// 1F801DB8h - Current Main Volume Left/Right
+// 0-15  Current Volume Left  (-8000h..+7FFFh)
+// 16-31 Current Volume Right (-8000h..+7FFFh)
+union SPUCurrentMainVolume {
+    struct {
+        uint32_t left : 16;
+        uint32_t right : 16;
+    };
+
+    uint32_t value;
+
+    SPUCurrentMainVolume() : value() {}
+};
+
 enum SPURAMDataTransferControlType {
     Fill,
     NormalTransfer,
@@ -293,6 +307,7 @@ class SPU {
     SPURAMDataTransferControl RAMDataTransferControl;
     SPURAMDataTransferAddress RAMDataTransferAddress;
     SPUVoiceKeyOn voiceKeyOn;
+    SPUCurrentMainVolume currentMainVolume;
 
     uint16_t controlRegister() const;
     void setControlRegister(uint16_t value);
@@ -317,6 +332,10 @@ class SPU {
     void setRAMDataTransferAddressRegister(uint16_t value);
     uint32_t voiceKeyOnRegister() const;
     void setVoiceKeyOnRegister(uint32_t value);
+    void setCurrentMainVolumeLeft(uint16_t value);
+    uint16_t currentMainVolumeLeft() const;
+    void setCurrentMainVolumeRight(uint16_t value);
+    uint16_t currentMainVolumeRight() const;
 public:
     SPU(LogLevel logLevel);
     ~SPU();

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -182,6 +182,20 @@ union SPUCDAudioInputVolume {
     SPUCDAudioInputVolume() : value() {}
 };
 
+// 1F801DB4h - External Audio Input Volume
+// 0-15  Volume Left   (-8000h..+7FFFh)
+// 16-31 Volume Right  (-8000h..+7FFFh)
+union SPUExternalAudoInputVolume {
+    struct {
+        uint32_t left : 16;
+        uint32_t right : 16;
+    };
+
+    uint32_t value;
+
+    SPUExternalAudoInputVolume() : value() {}
+};
+
 class SPU {
     Logger logger;
 
@@ -192,6 +206,7 @@ class SPU {
     SPUNoiseModeEnable noiseModeEnable;
     SPUReverbMode reverbMode;
     SPUCDAudioInputVolume CDAudioInputVolume;
+    SPUExternalAudoInputVolume externalAudioInputVolume;
 
     uint16_t controlRegister() const;
     void setControlRegister(uint16_t value);
@@ -207,6 +222,10 @@ class SPU {
     uint16_t CDAudioInputVolumeLeft() const;
     void setCDAudioInputVolumeRight(uint16_t value);
     uint16_t CDAudioInputVolumeRight() const;
+    void setExternalAudioInputVolumeLeft(uint16_t value);
+    uint16_t externalAudioInputVolumeLeft() const;
+    void setExternalAudioInputVolumeRight(uint16_t value);
+    uint16_t externalAudioInputVolumeRight() const;
 public:
     SPU(LogLevel logLevel);
     ~SPU();

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -100,17 +100,44 @@ struct SPUVoiceKeyOff {
     }
 };
 
+enum SPUPitchModulationEnableFlagValue {
+    NormalFrequency = 0,
+    ModulateByPreviousVoice = 1,
+};
+
+// 1F801D90h - Voice 0..23 Pitch Modulation Enable Flags (PMON)
+// Pitch modulation allows to generate "Frequency Sweep" effects by mis-using the amplitude from channel (x-1) as pitch factor for channel (x).
+// 0     Unknown... Unused?
+// 1-23  Flags for Voice 1..23 (0=Normal, 1=Modulate by Voice 0..22)
+// 24-31 Not used
+struct SPUPitchModulationEnableFlags {
+    uint32_t value;
+
+    SPUPitchModulationEnableFlags() : value() {}
+
+    SPUPitchModulationEnableFlagValue pitchModulationEnableFlagValueAtIndex(uint8_t voiceIndex) {
+        if (voiceIndex >= 24 || voiceIndex < 1) {
+            std::cout << format("Unsupported index %d for KOFF SPU register", voiceIndex) << std::endl;
+            exit(1);
+        }
+        return SPUPitchModulationEnableFlagValue((value >> voiceIndex) & 0x1);
+    }
+};
+
 class SPU {
     Logger logger;
 
     SPUControl control;
     SPUStatus status;
     SPUVoiceKeyOff voiceKeyOff;
+    SPUPitchModulationEnableFlags pitchModulationEnableFlags;
 
     uint16_t controlRegister() const;
     void setControlRegister(uint16_t value);
     uint16_t statusRegister() const;
     void setVoiceKeyOffRegister(uint32_t value);
+    void setPitchModulationEnableFlagsRegister(uint32_t value);
+    uint32_t pitchModulationEnableFlagsRegister() const;
 public:
     SPU(LogLevel logLevel);
     ~SPU();

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -43,13 +43,48 @@ union SPUControl {
     SPUControlRAMTransferMode RAMTransferMode() { return SPUControlRAMTransferMode(_RAMTransferMode); }
 };
 
+enum SPUStatusCaptureBufferWrite {
+    FirstHalf = 0,
+    SecondHalf = 1,
+};
+
+// 1F801DAEh - SPU Status Register (SPUSTAT) (R)
+// 15-12 Unknown/Unused (seems to be usually zero)
+// 11    Writing to First/Second half of Capture Buffers (0=First, 1=Second)
+// 10    Data Transfer Busy Flag          (0=Ready, 1=Busy)
+// 9     Data Transfer DMA Read Request   (0=No, 1=Yes)
+// 8     Data Transfer DMA Write Request  (0=No, 1=Yes)
+// 7     Data Transfer DMA Read/Write Request ;seems to be same as SPUCNT.Bit5
+// 6     IRQ9 Flag                        (0=No, 1=Interrupt Request)
+// 5-0   Current SPU Mode   (same as SPUCNT.Bit5-0, but, applied a bit delayed)
+union SPUStatus {
+    struct {
+        uint16_t currentMode : 5;
+        uint16_t IRQFlag : 1;
+        uint16_t dataTransferDMAReadWriteRequest : 1;
+        uint16_t dataTransferDMAWWriteequest : 1;
+        uint16_t dataTransferDMAWReadequest : 1;
+        uint16_t dataTransferBusyFlag : 1;
+        uint16_t _captureBufferWrite : 1;
+        uint16_t unknown : 4;
+    };
+
+    uint16_t value;
+
+    SPUStatus() : value() {}
+
+    SPUStatusCaptureBufferWrite captureBufferWrite() { return SPUStatusCaptureBufferWrite(_captureBufferWrite); }
+};
+
 class SPU {
     Logger logger;
 
     SPUControl control;
+    SPUStatus status;
 
     uint16_t controlRegister() const;
     void setControlRegister(uint16_t value);
+    uint16_t statusRegister() const;
 public:
     SPU(LogLevel logLevel);
     ~SPU();

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -244,6 +244,19 @@ union SPURAMDataTransferControl {
     }
 };
 
+
+// 1F801DA6h - Sound RAM Data Transfer Address
+// 15-0  Address in sound buffer divided by eight
+union SPURAMDataTransferAddress {
+    struct {
+        uint16_t address : 16;
+    };
+
+    uint16_t value;
+
+    SPURAMDataTransferAddress() : value() {}
+};
+
 class SPU {
     Logger logger;
 
@@ -256,6 +269,7 @@ class SPU {
     SPUCDAudioInputVolume CDAudioInputVolume;
     SPUExternalAudoInputVolume externalAudioInputVolume;
     SPURAMDataTransferControl RAMDataTransferControl;
+    SPURAMDataTransferAddress RAMDataTransferAddress;
 
     uint16_t controlRegister() const;
     void setControlRegister(uint16_t value);
@@ -276,6 +290,7 @@ class SPU {
     void setExternalAudioInputVolumeRight(uint16_t value);
     uint16_t externalAudioInputVolumeRight() const;
     void setRAMDataTransferControlRegister(uint16_t value);
+    void setRAMDataTransferAddressRegister(uint16_t value);
 public:
     SPU(LogLevel logLevel);
     ~SPU();

--- a/include/SPU.hpp
+++ b/include/SPU.hpp
@@ -79,7 +79,7 @@ union SPUStatus {
 };
 
 enum SPUVoiceKeyOffValue {
-    NoChange = 0,
+    NoChangeKeyOff = 0,
     StartRelease = 1,
 };
 
@@ -97,6 +97,28 @@ struct SPUVoiceKeyOff {
             exit(1);
         }
         return SPUVoiceKeyOffValue((value >> voiceIndex) & 0x1);
+    }
+};
+
+enum SPUVoiceKeyOnValue {
+    NoChangeKeyOn = 0,
+    StartAttackDecaySustain = 1,
+};
+
+// 1F801D88h - Voice 0..23 Key ON (Start Attack/Decay/Sustain) (KON) (W)
+// 0-23  Voice 0..23 On  (0=No change, 1=Start Attack/Decay/Sustain)
+// 24-31 Not used
+struct SPUVoiceKeyOn {
+    uint32_t value;
+
+    SPUVoiceKeyOn() : value() {}
+
+    SPUVoiceKeyOnValue voiceKeyOffValueAtIndex(uint8_t voiceIndex) {
+        if (voiceIndex >= 24) {
+            std::cout << format("Unsupported index %d for KON SPU register", voiceIndex) << std::endl;
+            exit(1);
+        }
+        return SPUVoiceKeyOnValue((value >> voiceIndex) & 0x1);
     }
 };
 
@@ -270,6 +292,7 @@ class SPU {
     SPUExternalAudoInputVolume externalAudioInputVolume;
     SPURAMDataTransferControl RAMDataTransferControl;
     SPURAMDataTransferAddress RAMDataTransferAddress;
+    SPUVoiceKeyOn voiceKeyOn;
 
     uint16_t controlRegister() const;
     void setControlRegister(uint16_t value);
@@ -291,6 +314,8 @@ class SPU {
     uint16_t externalAudioInputVolumeRight() const;
     void setRAMDataTransferControlRegister(uint16_t value);
     void setRAMDataTransferAddressRegister(uint16_t value);
+    uint32_t voiceKeyOnRegister() const;
+    void setVoiceKeyOnRegister(uint32_t value);
 public:
     SPU(LogLevel logLevel);
     ~SPU();

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -7,6 +7,10 @@ inline T SPU::load(uint32_t offset) const {
         logger.logMessage("Unhandled Sound Processing Unit voice register read");
         return 0;
     }
+    if (offset >= 0x1c0 && offset <= 0x1ff) {
+        logger.logMessage("Unhandled Sound Processing Unit reverb configuration area read");
+        return 0;
+    }
     switch (offset) {
         case 0x1ae: {
             return statusRegister();
@@ -60,6 +64,10 @@ inline void SPU::store(uint32_t offset, T value) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     if (offset >= 0 && offset <= 0x17f) {
         logger.logMessage("Unhandled Sound Processing Unit voice register write");
+        return;
+    }
+    if (offset >= 0x1c0 && offset <= 0x1ff) {
+        logger.logMessage("Unhandled Sound Processing Unit reverb configuration area read");
         return;
     }
     switch (offset) {

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -59,6 +59,24 @@ inline void SPU::store(uint32_t offset, T value) {
             setVoiceKeyOffRegister(toWrite);
             break;
         }
+        case 0x190: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported PMON write with size: %d", sizeof(T));
+            }
+            uint32_t upper = (pitchModulationEnableFlags.value >> 16) << 16;
+            uint32_t toWrite = upper | value;
+            setPitchModulationEnableFlagsRegister(toWrite);
+            break;
+        }
+        case 0x192: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported PMON write with size: %d", sizeof(T));
+            }
+            uint32_t lower = pitchModulationEnableFlags.value & 0xFFFF;
+            uint32_t toWrite = (value << 16) | lower;
+            setPitchModulationEnableFlagsRegister(toWrite);
+            break;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
             return;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -7,6 +7,9 @@ inline T SPU::load(uint32_t offset) const {
         case 0x1ae: {
             return statusRegister();
         }
+        case 0x1aa: {
+            return controlRegister();
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit read at offset: %#x, of size: %d", offset, sizeof(T));
             return 0;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -70,6 +70,20 @@ inline T SPU::load(uint32_t offset) const {
             }
             return RAMDataTransferControlRegister();
         }
+        case 0x198: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported EON write with size: %d", sizeof(T));
+            }
+            uint16_t lower = reverbMode.value & 0xFFFF;
+            return lower;
+        }
+        case 0x19a: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported EON write with size: %d", sizeof(T));
+            }
+            uint16_t upper = (reverbMode.value >> 16) << 16;
+            return upper;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit read at offset: %#x, of size: %d", offset, sizeof(T));
             return 0;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -141,6 +141,13 @@ inline void SPU::store(uint32_t offset, T value) {
             setExternalAudioInputVolumeRight(value);
             break;
         }
+        case 0x1ac: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported Sound RAM Data Transfer Control write with size: %d", sizeof(T));
+            }
+            setRAMDataTransferControlRegister(value);
+            break;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
             return;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -77,6 +77,24 @@ inline void SPU::store(uint32_t offset, T value) {
             setPitchModulationEnableFlagsRegister(toWrite);
             break;
         }
+        case 0x194: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported NON write with size: %d", sizeof(T));
+            }
+            uint32_t upper = (noiseModeEnable.value >> 16) << 16;
+            uint32_t toWrite = upper | value;
+            setNoiseModeEnableRegister(toWrite);
+            break;
+        }
+        case 0x196: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported NON write with size: %d", sizeof(T));
+            }
+            uint32_t lower = noiseModeEnable.value & 0xFFFF;
+            uint32_t toWrite = (value << 16) | lower;
+            setNoiseModeEnableRegister(toWrite);
+            break;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
             return;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -4,6 +4,9 @@ template <typename T>
 inline T SPU::load(uint32_t offset) const {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
     switch (offset) {
+        case 0x1ae: {
+            return statusRegister();
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit read at offset: %#x, of size: %d", offset, sizeof(T));
             return 0;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -14,7 +14,6 @@ inline T SPU::load(uint32_t offset) const {
 template <typename T>
 inline void SPU::store(uint32_t offset, T value) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
-    (void)value;
     switch (offset) {
         case 0x180: {
             logger.logMessage("Unhandled Sound Processing Unit main volume left write");
@@ -30,6 +29,13 @@ inline void SPU::store(uint32_t offset, T value) {
         }
         case 0x186: {
             logger.logMessage("Unhandled Sound Processing Unit reverb volume output right write");
+            break;
+        }
+        case 0x1aa: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported SPUCNT write with size: %d", sizeof(T));
+            }
+            setControlRegister(value);
             break;
         }
         default: {

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -1,0 +1,15 @@
+#include "SPU.hpp"
+
+template <typename T>
+inline T SPU::load(uint32_t offset) const {
+    static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
+    (void)offset;
+    return 0;
+}
+
+template <typename T>
+inline void SPU::store(uint32_t offset, T value) {
+    static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
+    (void)offset;
+    (void)value;
+}

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -41,6 +41,24 @@ inline void SPU::store(uint32_t offset, T value) {
             setControlRegister(value);
             break;
         }
+        case 0x18c: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported KOFF write with size: %d", sizeof(T));
+            }
+            uint32_t upper = (voiceKeyOff.value >> 16) << 16;
+            uint32_t toWrite = upper | value;
+            setVoiceKeyOffRegister(toWrite);
+            break;
+        }
+        case 0x18e: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported KOFF write with size: %d", sizeof(T));
+            }
+            uint32_t lower = voiceKeyOff.value & 0xFFFF;
+            uint32_t toWrite = (value << 16) | lower;
+            setVoiceKeyOffRegister(toWrite);
+            break;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
             return;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -14,6 +14,34 @@ inline T SPU::load(uint32_t offset) const {
         case 0x1aa: {
             return controlRegister();
         }
+        case 0x188: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported KON read with size: %d", sizeof(T));
+            }
+            uint16_t lower = voiceKeyOn.value & 0xFFFF;
+            return lower;
+        }
+        case 0x18a: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported KON read with size: %d", sizeof(T));
+            }
+            uint16_t upper = voiceKeyOn.value >> 16;
+            return upper;
+        }
+        case 0x18c: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported KOFF read with size: %d", sizeof(T));
+            }
+            uint16_t lower = voiceKeyOff.value & 0xFFFF;
+            return lower;
+        }
+        case 0x18e: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported KOFF read with size: %d", sizeof(T));
+            }
+            uint16_t upper = voiceKeyOff.value >> 16;
+            return upper;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit read at offset: %#x, of size: %d", offset, sizeof(T));
             return 0;
@@ -168,6 +196,24 @@ inline void SPU::store(uint32_t offset, T value) {
         }
         case 0x1a8: {
             logger.logWarning("Unhandled Sound RAM Data Transfer FIFO write");
+            break;
+        }
+        case 0x188: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported KON write with size: %d", sizeof(T));
+            }
+            uint32_t upper = (voiceKeyOn.value >> 16) << 16;
+            uint32_t toWrite = upper | value;
+            setVoiceKeyOnRegister(toWrite);
+            break;
+        }
+        case 0x18A: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported KON write with size: %d", sizeof(T));
+            }
+            uint32_t lower = voiceKeyOn.value & 0xFFFF;
+            uint32_t toWrite = (value << 16) | lower;
+            setVoiceKeyOnRegister(toWrite);
             break;
         }
         default: {

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -3,13 +3,38 @@
 template <typename T>
 inline T SPU::load(uint32_t offset) const {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
-    (void)offset;
-    return 0;
+    switch (offset) {
+        default: {
+            logger.logError("Unhandled Sound Processing Unit read at offset: %#x, of size: %d", offset, sizeof(T));
+            return 0;
+        }
+    }
 }
 
 template <typename T>
 inline void SPU::store(uint32_t offset, T value) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
-    (void)offset;
     (void)value;
+    switch (offset) {
+        case 0x180: {
+            logger.logMessage("Unhandled Sound Processing Unit main volume left write");
+            break;
+        }
+        case 0x182: {
+            logger.logMessage("Unhandled Sound Processing Unit main volume right write");
+            break;
+        }
+        case 0x184: {
+            logger.logMessage("Unhandled Sound Processing Unit reverb volume output left write");
+            break;
+        }
+        case 0x186: {
+            logger.logMessage("Unhandled Sound Processing Unit reverb volume output right write");
+            break;
+        }
+        default: {
+            logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
+            return;
+        }
+    }
 }

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -64,6 +64,12 @@ inline T SPU::load(uint32_t offset) const {
             }
             return currentMainVolumeRight();
         }
+        case 0x1a6: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported Sound RAM Data Transfer Address read with size: %d", sizeof(T));
+            }
+            return RAMDataTransferControlRegister();
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit read at offset: %#x, of size: %d", offset, sizeof(T));
             return 0;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -249,6 +249,24 @@ inline void SPU::store(uint32_t offset, T value) {
             logger.logWarning("Unhandled Sound RAM Reverb Work Area Start Address");
             break;
         }
+        case 0x19c: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported voice status write with size: %d", sizeof(T));
+            }
+            uint32_t upper = (voiceStatus.value >> 16) << 16;
+            uint32_t toWrite = upper | value;
+            setVoiceStatusRegister(toWrite);
+            break;
+        }
+        case 0x19e: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported voice status write with size: %d", sizeof(T));
+            }
+            uint32_t lower = voiceKeyOn.value & 0xFFFF;
+            uint32_t toWrite = (value << 16) | lower;
+            setVoiceStatusRegister(toWrite);
+            break;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
             return;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -148,6 +148,13 @@ inline void SPU::store(uint32_t offset, T value) {
             setRAMDataTransferControlRegister(value);
             break;
         }
+        case 0x1a6: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported Sound RAM Data Transfer Address write with size: %d", sizeof(T));
+            }
+            setRAMDataTransferAddressRegister(value);
+            break;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
             return;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -42,6 +42,12 @@ inline T SPU::load(uint32_t offset) const {
             uint16_t upper = voiceKeyOff.value >> 16;
             return upper;
         }
+        case 0x1ac: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported RAM Data Transfer Control read with size: %d", sizeof(T));
+            }
+            return RAMDataTransferControlRegister();
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit read at offset: %#x, of size: %d", offset, sizeof(T));
             return 0;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -127,6 +127,20 @@ inline void SPU::store(uint32_t offset, T value) {
             setCDAudioInputVolumeRight(value);
             break;
         }
+        case 0x1b4: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported External Audio Input Volume write with size: %d", sizeof(T));
+            }
+            setExternalAudioInputVolumeLeft(value);
+            break;
+        }
+        case 0x1b6: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported External Audio Input Volume write with size: %d", sizeof(T));
+            }
+            setExternalAudioInputVolumeRight(value);
+            break;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
             return;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -113,6 +113,20 @@ inline void SPU::store(uint32_t offset, T value) {
             setReverbModeRegister(toWrite);
             break;
         }
+        case 0x1b0: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported CD Audio Input Volume write with size: %d", sizeof(T));
+            }
+            setCDAudioInputVolumeLeft(value);
+            break;
+        }
+        case 0x1b2: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported CD Audio Input Volume write with size: %d", sizeof(T));
+            }
+            setCDAudioInputVolumeRight(value);
+            break;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
             return;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -222,6 +222,13 @@ inline void SPU::store(uint32_t offset, T value) {
             setVoiceKeyOnRegister(toWrite);
             break;
         }
+        case 0x1a2: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported Sound RAM Reverb Work Area Start Address write with size: %d", sizeof(T));
+            }
+            logger.logWarning("Unhandled Sound RAM Reverb Work Area Start Address");
+            break;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
             return;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -155,6 +155,10 @@ inline void SPU::store(uint32_t offset, T value) {
             setRAMDataTransferAddressRegister(value);
             break;
         }
+        case 0x1a8: {
+            logger.logWarning("Unhandled Sound RAM Data Transfer FIFO write");
+            break;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
             return;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -52,6 +52,18 @@ inline T SPU::load(uint32_t offset) const {
             }
             return RAMDataTransferControlRegister();
         }
+        case 0x1b8: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported Current Main Volume read with size: %d", sizeof(T));
+            }
+            return currentMainVolumeLeft();
+        }
+        case 0x1ba: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported Current Main Volume read with size: %d", sizeof(T));
+            }
+            return currentMainVolumeRight();
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit read at offset: %#x, of size: %d", offset, sizeof(T));
             return 0;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -95,6 +95,24 @@ inline void SPU::store(uint32_t offset, T value) {
             setNoiseModeEnableRegister(toWrite);
             break;
         }
+        case 0x198: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported EON write with size: %d", sizeof(T));
+            }
+            uint32_t upper = (reverbMode.value >> 16) << 16;
+            uint32_t toWrite = upper | value;
+            setReverbModeRegister(toWrite);
+            break;
+        }
+        case 0x19a: {
+            if (sizeof(T) != 2) {
+                logger.logError("Unsupported EON write with size: %d", sizeof(T));
+            }
+            uint32_t lower = reverbMode.value & 0xFFFF;
+            uint32_t toWrite = (value << 16) | lower;
+            setReverbModeRegister(toWrite);
+            break;
+        }
         default: {
             logger.logError("Unhandled Sound Processing Unit write at offset: %#x, of size: %d", offset, sizeof(T));
             return;

--- a/include/SPU.tcc
+++ b/include/SPU.tcc
@@ -3,6 +3,10 @@
 template <typename T>
 inline T SPU::load(uint32_t offset) const {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
+    if (offset >= 0 && offset <= 0x17f) {
+        logger.logMessage("Unhandled Sound Processing Unit voice register read");
+        return 0;
+    }
     switch (offset) {
         case 0x1ae: {
             return statusRegister();
@@ -20,6 +24,10 @@ inline T SPU::load(uint32_t offset) const {
 template <typename T>
 inline void SPU::store(uint32_t offset, T value) {
     static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
+    if (offset >= 0 && offset <= 0x17f) {
+        logger.logMessage("Unhandled Sound Processing Unit voice register write");
+        return;
+    }
     switch (offset) {
         case 0x180: {
             logger.logMessage("Unhandled Sound Processing Unit main volume left write");

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -56,6 +56,7 @@ void ConfigurationManager::setupConfigurationFile() {
     logConfigurationRef["gpu"] = "NOLOG";
     logConfigurationRef["opengl"] = "NOLOG";
     logConfigurationRef["dma"] = "NOLOG";
+    logConfigurationRef["spu"] = "NOLOG";
     logConfigurationRef["trace"] = "false";
     Yaml::Node configuration = Yaml::Node();
     Yaml::Node &configurationRef = configuration;
@@ -78,6 +79,7 @@ void ConfigurationManager::loadConfiguration() {
     gpu = logLevelWithValue(configuration["log"]["gpu"].As<string>());
     opengl = logLevelWithValue(configuration["log"]["opengl"].As<string>());
     dma = logLevelWithValue(configuration["log"]["dma"].As<string>());
+    spu = logLevelWithValue(configuration["log"]["spu"].As<string>());
     trace = configuration["log"]["trace"].As<bool>();
     if (trace) {
         remove("ruby.log");
@@ -118,6 +120,10 @@ LogLevel ConfigurationManager::openGLLogLevel() {
 
 LogLevel ConfigurationManager::dmaLogLevel() {
     return dma;
+}
+
+LogLevel ConfigurationManager::spuLogLevel() {
+    return spu;
 }
 
 bool ConfigurationManager::shouldTraceLogs() {

--- a/src/DMA.cpp
+++ b/src/DMA.cpp
@@ -207,7 +207,7 @@ string DMA::portDescription(DMAPort port) {
             return "GPU";
         case CDROMP:
             return "CDROM";
-        case SPU:
+        case SPUP:
             return "SPU";
         case PIO:
             return "PIO";

--- a/src/DMA.cpp
+++ b/src/DMA.cpp
@@ -147,6 +147,11 @@ void DMA::executeBlock(DMAPort port, Channel& channel) {
                         gpu->executeGp0(source);
                         break;
                     }
+                    case DMAPort::SPUP: {
+                        logger.logWarning("Unhandled DMA block transfer from RAM to source port: %s", portDescription(port).c_str());
+                        goto unhandled;
+                        break;
+                    }
                     default: {
                         logger.logError("Unhandled DMA block transfer from RAM to source port: %s", portDescription(port).c_str());
                         break;
@@ -186,6 +191,7 @@ void DMA::executeBlock(DMAPort port, Channel& channel) {
         address += step;
         remainingTransferSize -= 1;
     }
+unhandled:
     channel.done();
     return;
 }

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -53,7 +53,11 @@ CPU* Emulator::getCPU() {
 }
 
 void Emulator::emulateFrame() {
-    uint32_t systemClockStep = 21;
+    // Emulate cpu for given time slice (21 * magicNumber cycles),
+    // then check what events occured during that time slice,
+    // finally simulate rest of hardware to accommodate for that
+    uint32_t emulationMagicNumber = 4;
+    uint32_t systemClockStep = 21 * emulationMagicNumber;
     uint32_t videoSystemClockStep = systemClockStep*11/7;
     uint32_t totalSystemClocksThisFrame = 0;
     uint32_t videoSystemClocksScanlineCounter = 0;

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -42,7 +42,7 @@ Emulator::Emulator() : logger(LogLevel::NoLog), ttyBuffer(), biosFunctionsLog() 
     timer2 = make_unique<Timer2>();
     controller = make_unique<Controller>();
     spu = make_unique<SPU>();
-    interconnect = make_unique<Interconnect>(configurationManager->interconnectLogLevel(), cop0, bios, ram, gpu, dma, scratchpad, cdrom, interruptController, expansion1, timer0, timer1, timer2, controller);
+    interconnect = make_unique<Interconnect>(configurationManager->interconnectLogLevel(), cop0, bios, ram, gpu, dma, scratchpad, cdrom, interruptController, expansion1, timer0, timer1, timer2, controller, spu);
     cpu = make_unique<CPU>(configurationManager->cpuLogLevel(), interconnect, cop0, logBiosFunctionCalls);
 }
 

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -41,6 +41,7 @@ Emulator::Emulator() : logger(LogLevel::NoLog), ttyBuffer(), biosFunctionsLog() 
     timer1 = make_unique<Timer1>();
     timer2 = make_unique<Timer2>();
     controller = make_unique<Controller>();
+    spu = make_unique<SPU>();
     interconnect = make_unique<Interconnect>(configurationManager->interconnectLogLevel(), cop0, bios, ram, gpu, dma, scratchpad, cdrom, interruptController, expansion1, timer0, timer1, timer2, controller);
     cpu = make_unique<CPU>(configurationManager->cpuLogLevel(), interconnect, cop0, logBiosFunctionCalls);
 }

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -41,7 +41,7 @@ Emulator::Emulator() : logger(LogLevel::NoLog), ttyBuffer(), biosFunctionsLog() 
     timer1 = make_unique<Timer1>();
     timer2 = make_unique<Timer2>();
     controller = make_unique<Controller>();
-    spu = make_unique<SPU>();
+    spu = make_unique<SPU>(configurationManager->spuLogLevel());
     interconnect = make_unique<Interconnect>(configurationManager->interconnectLogLevel(), cop0, bios, ram, gpu, dma, scratchpad, cdrom, interruptController, expansion1, timer0, timer1, timer2, controller, spu);
     cpu = make_unique<CPU>(configurationManager->cpuLogLevel(), interconnect, cop0, logBiosFunctionCalls);
 }

--- a/src/Interconnect.cpp
+++ b/src/Interconnect.cpp
@@ -15,7 +15,7 @@ const uint32_t regionMask[8] = {
     0xffffffff, 0xffffffff,
 };
 
-Interconnect::Interconnect(LogLevel logLevel, std::unique_ptr<COP0> &cop0, unique_ptr<BIOS> &bios, unique_ptr<RAM> &ram, unique_ptr<GPU> &gpu, unique_ptr<DMA> &dma, unique_ptr<Scratchpad> &scratchpad, unique_ptr<CDROM> &cdrom, unique_ptr<InterruptController> &interruptController, unique_ptr<Expansion1> &expansion1, std::unique_ptr<Timer0> &timer0, std::unique_ptr<Timer1> &timer1, std::unique_ptr<Timer2> &timer2, std::unique_ptr<Controller> &controller) : logger(logLevel), cop0(cop0), bios(bios), ram(ram), gpu(gpu), dma(dma), scratchpad(scratchpad), cdrom(cdrom), interruptController(interruptController), expansion1(expansion1), timer0(timer0), timer1(timer1), timer2(timer2), controller(controller) {
+Interconnect::Interconnect(LogLevel logLevel, std::unique_ptr<COP0> &cop0, unique_ptr<BIOS> &bios, unique_ptr<RAM> &ram, unique_ptr<GPU> &gpu, unique_ptr<DMA> &dma, unique_ptr<Scratchpad> &scratchpad, unique_ptr<CDROM> &cdrom, unique_ptr<InterruptController> &interruptController, unique_ptr<Expansion1> &expansion1, std::unique_ptr<Timer0> &timer0, std::unique_ptr<Timer1> &timer1, std::unique_ptr<Timer2> &timer2, std::unique_ptr<Controller> &controller, std::unique_ptr<SPU> &spu) : logger(logLevel), cop0(cop0), bios(bios), ram(ram), gpu(gpu), dma(dma), scratchpad(scratchpad), cdrom(cdrom), interruptController(interruptController), expansion1(expansion1), timer0(timer0), timer1(timer1), timer2(timer2), controller(controller), spu(spu) {
     bios->loadBin("SCPH1001.BIN");
     EmulatorRunner *emulatorRunner = EmulatorRunner::getInstance();
     if (emulatorRunner->shouldRunTests()) {

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -1,6 +1,6 @@
 #include "SPU.hpp"
 
-SPU::SPU(LogLevel logLevel) : logger(logLevel, "  SPU: "), control(), status() {
+SPU::SPU(LogLevel logLevel) : logger(logLevel, "  SPU: "), control(), status(), voiceKeyOff() {
 
 }
 
@@ -20,4 +20,8 @@ void SPU::setControlRegister(uint16_t value) {
 
 uint16_t SPU::statusRegister() const {
     return status.value;
+}
+
+void SPU::setVoiceKeyOffRegister(uint32_t value) {
+    voiceKeyOff.value = value;
 }

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -101,3 +101,19 @@ uint32_t SPU::voiceKeyOnRegister() const {
 void SPU::setVoiceKeyOnRegister(uint32_t value) {
     voiceKeyOn.value = value;
 }
+
+void SPU::setCurrentMainVolumeLeft(uint16_t value) {
+    currentMainVolume.left = value;
+}
+
+uint16_t SPU::currentMainVolumeLeft() const {
+    return currentMainVolume.left;
+}
+
+void SPU::setCurrentMainVolumeRight(uint16_t value) {
+    currentMainVolume.right = value;
+}
+
+uint16_t SPU::currentMainVolumeRight() const {
+    return currentMainVolume.right;
+}

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -1,9 +1,17 @@
 #include "SPU.hpp"
 
-SPU::SPU(LogLevel logLevel) : logger(logLevel, "  SPU: ") {
+SPU::SPU(LogLevel logLevel) : logger(logLevel, "  SPU: "), control() {
 
 }
 
 SPU::~SPU() {
 
+}
+
+uint16_t SPU::controlRegister() const {
+    return control.value;
+}
+
+void SPU::setControlRegister(uint16_t value) {
+    control.value = value;
 }

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -89,3 +89,11 @@ void SPU::setRAMDataTransferControlRegister(uint16_t value) {
 void SPU::setRAMDataTransferAddressRegister(uint16_t value) {
     RAMDataTransferControl.value = value;
 }
+
+uint32_t SPU::voiceKeyOnRegister() const {
+    return voiceKeyOn.value;
+}
+
+void SPU::setVoiceKeyOnRegister(uint32_t value) {
+    voiceKeyOn.value = value;
+}

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -33,3 +33,11 @@ void SPU::setPitchModulationEnableFlagsRegister(uint32_t value) {
 uint32_t SPU::pitchModulationEnableFlagsRegister() const {
     return pitchModulationEnableFlags.value;
 }
+
+void SPU::setNoiseModeEnableRegister(uint32_t value) {
+    noiseModeEnable.value = value;
+}
+
+uint32_t SPU::noiseModeEnableRegister() const {
+    return noiseModeEnable.value;
+}

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -1,6 +1,6 @@
 #include "SPU.hpp"
 
-SPU::SPU() {
+SPU::SPU(LogLevel logLevel) : logger(logLevel, "  SPU: ") {
 
 }
 

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -86,6 +86,10 @@ void SPU::setRAMDataTransferControlRegister(uint16_t value) {
     RAMDataTransferControl.value = value;
 }
 
+uint16_t SPU::RAMDataTransferControlRegister() const {
+    return RAMDataTransferControl.value;
+}
+
 void SPU::setRAMDataTransferAddressRegister(uint16_t value) {
     RAMDataTransferControl.value = value;
 }

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -65,3 +65,19 @@ void SPU::setCDAudioInputVolumeRight(uint16_t value) {
 uint16_t SPU::CDAudioInputVolumeRight() const {
     return CDAudioInputVolume.right;
 }
+
+void SPU::setExternalAudioInputVolumeLeft(uint16_t value) {
+    externalAudioInputVolume.left = value;
+}
+
+uint16_t SPU::externalAudioInputVolumeLeft() const {
+    return externalAudioInputVolume.left;
+}
+
+void SPU::setExternalAudioInputVolumeRight(uint16_t value) {
+    externalAudioInputVolume.right = value;
+}
+
+uint16_t SPU::externalAudioInputVolumeRight() const {
+    return externalAudioInputVolume.right;
+}

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -1,6 +1,6 @@
 #include "SPU.hpp"
 
-SPU::SPU(LogLevel logLevel) : logger(logLevel, "  SPU: "), control() {
+SPU::SPU(LogLevel logLevel) : logger(logLevel, "  SPU: "), control(), status() {
 
 }
 
@@ -13,5 +13,11 @@ uint16_t SPU::controlRegister() const {
 }
 
 void SPU::setControlRegister(uint16_t value) {
+    // TODO: mirror Bit5-0 to SPUSTAT.Bit5-0
+    // docs say it should be a delayed write
     control.value = value;
+}
+
+uint16_t SPU::statusRegister() const {
+    return status.value;
 }

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -41,3 +41,11 @@ void SPU::setNoiseModeEnableRegister(uint32_t value) {
 uint32_t SPU::noiseModeEnableRegister() const {
     return noiseModeEnable.value;
 }
+
+void SPU::setReverbModeRegister(uint32_t value) {
+    reverbMode.value = value;
+}
+
+uint32_t SPU::reverbModeRegister() const {
+    return reverbMode.value;
+}

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -49,3 +49,19 @@ void SPU::setReverbModeRegister(uint32_t value) {
 uint32_t SPU::reverbModeRegister() const {
     return reverbMode.value;
 }
+
+void SPU::setCDAudioInputVolumeLeft(uint16_t value) {
+    CDAudioInputVolume.left = value;
+}
+
+uint16_t SPU::CDAudioInputVolumeLeft() const {
+    return CDAudioInputVolume.left;
+}
+
+void SPU::setCDAudioInputVolumeRight(uint16_t value) {
+    CDAudioInputVolume.right = value;
+}
+
+uint16_t SPU::CDAudioInputVolumeRight() const {
+    return CDAudioInputVolume.right;
+}

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -81,3 +81,7 @@ void SPU::setExternalAudioInputVolumeRight(uint16_t value) {
 uint16_t SPU::externalAudioInputVolumeRight() const {
     return externalAudioInputVolume.right;
 }
+
+void SPU::setRAMDataTransferControlRegister(uint16_t value) {
+    RAMDataTransferControl.value = value;
+}

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -9,20 +9,24 @@ SPU::~SPU() {
 }
 
 uint16_t SPU::controlRegister() const {
+    logger.logMessage("SPUCNT [R]: %#x", control.value);
     return control.value;
 }
 
 void SPU::setControlRegister(uint16_t value) {
+    logger.logMessage("SPUCNT [W]: %#x", value);
     // TODO: mirror Bit5-0 to SPUSTAT.Bit5-0
     // docs say it should be a delayed write
     control.value = value;
 }
 
 uint16_t SPU::statusRegister() const {
+    logger.logMessage("SPUSTAT [R]: %#x", control.value);
     return status.value;
 }
 
 void SPU::setVoiceKeyOffRegister(uint32_t value) {
+    logger.logMessage("SPUSTAT [W]: %#x", value);
     voiceKeyOff.value = value;
 }
 

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -117,3 +117,11 @@ void SPU::setCurrentMainVolumeRight(uint16_t value) {
 uint16_t SPU::currentMainVolumeRight() const {
     return currentMainVolume.right;
 }
+
+uint32_t SPU::voiceStatusRegister() const {
+    return voiceStatus.value;
+}
+
+void SPU::setVoiceStatusRegister(uint32_t value) {
+    voiceStatus.value = value;
+}

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -1,0 +1,9 @@
+#include "SPU.hpp"
+
+SPU::SPU() {
+
+}
+
+SPU::~SPU() {
+
+}

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -25,3 +25,11 @@ uint16_t SPU::statusRegister() const {
 void SPU::setVoiceKeyOffRegister(uint32_t value) {
     voiceKeyOff.value = value;
 }
+
+void SPU::setPitchModulationEnableFlagsRegister(uint32_t value) {
+    pitchModulationEnableFlags.value = value;
+}
+
+uint32_t SPU::pitchModulationEnableFlagsRegister() const {
+    return pitchModulationEnableFlags.value;
+}

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -85,3 +85,7 @@ uint16_t SPU::externalAudioInputVolumeRight() const {
 void SPU::setRAMDataTransferControlRegister(uint16_t value) {
     RAMDataTransferControl.value = value;
 }
+
+void SPU::setRAMDataTransferAddressRegister(uint16_t value) {
+    RAMDataTransferControl.value = value;
+}


### PR DESCRIPTION
This is an incomplete implementation of the Sound Processing Unit, but there is enough here to make the emulator go a bit further:

![Screenshot from 2019-10-24 23 43 53](https://user-images.githubusercontent.com/346590/67528013-a2f6a800-f6b8-11e9-9ab6-aac1314e7b6b.png)
 
Notes:

* The SPU memory range can be accessed by 32 or 16-bit read/writes. [This is a bit unusual in comparison to the other devices](http://problemkaputt.de/psx-spx.htm#unpredictablethings). **The implementation here doesn't handle all kinds of access**.
* Without these changes, DMA4 isn't triggered at all. This implementation doesn't really execute the DMA4, [instead it `goto`es it's way out of it :skull:](https://github.com/UnsafePointer/ruby/commit/cde46b56245f03ebcd43333742b29a718f795e6a). 
* [CD-ROM timings are pure sadness](https://github.com/UnsafePointer/ruby/pull/26/commits/69478f11ccdd82d61c1dc9bfad644a96c484ae4d).