### PR TITLE
Add flag to load ROMs to Expansion 1

### DIFF
--- a/include/EmulatorRunner.hpp
+++ b/include/EmulatorRunner.hpp
@@ -38,8 +38,10 @@ class EmulatorRunner {
     Logger logger;
     Emulator *emulator;
     bool runTests;
+    bool loadExpansionROM;
     std::filesystem::path exeFile;
     std::filesystem::path binFile;
+    std::filesystem::path romFile;
     uint8_t header[TEST_HEADER_SIZE];
 
     void readHeader();
@@ -58,6 +60,8 @@ public:
     void configure(int argc, char* argv[]);
     void setEmulator(Emulator *emulator);
     bool shouldRunTests();
+    bool shouldLoadExpansionROM();
+    std::filesystem::path romFilePath();
     uint32_t programCounter();
     uint32_t globalPointer();
     uint32_t initialStackFramePointerBase();

--- a/include/Expansion1.hpp
+++ b/include/Expansion1.hpp
@@ -12,4 +12,6 @@ public:
     void loadBin(const std::filesystem::path& filePath);
     template <typename T>
     inline T load(uint32_t offset) const;
+    template <typename T>
+    inline void store(uint32_t offset, T value);
 };

--- a/include/Expansion1.tcc
+++ b/include/Expansion1.tcc
@@ -10,3 +10,11 @@ inline T Expansion1::load(uint32_t offset) const {
     }
     return value;
 }
+
+template <typename T>
+inline void Expansion1::store(uint32_t offset, T value) {
+    static_assert(std::is_same<T, uint8_t>() || std::is_same<T, uint16_t>() || std::is_same<T, uint32_t>(), "Invalid type");
+    for (uint8_t i = 0; i < sizeof(T); i++) {
+        data[offset + i] = ((uint8_t)(((uint32_t)value) >> (i * 8)));
+    }
+}

--- a/include/Interconnect.tcc
+++ b/include/Interconnect.tcc
@@ -168,6 +168,11 @@ inline void Interconnect::store(uint32_t address, T value) const {
         timer2->store<T>(*offset, value);
         return;
     }
+    offset = expansion1Range.contains(absoluteAddress);
+    if (offset) {
+        expansion1->store<T>(*offset, value);
+        return;
+    }
     offset = soundProcessingUnitRange.contains(absoluteAddress);
     if (offset) {
         spu->store<T>(*offset, value);

--- a/src/EmulatorRunner.cpp
+++ b/src/EmulatorRunner.cpp
@@ -5,7 +5,7 @@
 
 using namespace std;
 
-EmulatorRunner::EmulatorRunner() : logger(LogLevel::NoLog), emulator(nullptr), runTests(false), exeFile(), binFile(), header() {}
+EmulatorRunner::EmulatorRunner() : logger(LogLevel::NoLog), emulator(nullptr), runTests(false), loadExpansionROM(false), exeFile(), binFile(), romFile(), header() {}
 
 EmulatorRunner* EmulatorRunner::instance = nullptr;
 
@@ -55,6 +55,18 @@ void EmulatorRunner::configure(int argc, char* argv[]) {
         }
         argumentFound = true;
     }
+    if (checkOption(argv, argv + argc, "--rom")) {
+        char *path = getOptionValue(argv, argv + argc, "--rom");
+        if (path == NULL) {
+            logger.logError("Incorrect argument passed. See README.md for usage.");
+        }
+        loadExpansionROM = true;
+        romFile = filesystem::current_path() / string(path);
+        if (!filesystem::exists(romFile)) {
+            logger.logError("The provided --rom filepath doesn't exist.");
+        }
+        argumentFound = true;
+    }
     if (!argumentFound) {
         logger.logError("Incorrect argument passed. See README.md for usage.");
     }
@@ -89,6 +101,14 @@ uint32_t EmulatorRunner::loadWord(uint32_t offset) {
 
 bool EmulatorRunner::shouldRunTests() {
     return runTests;
+}
+
+bool EmulatorRunner::shouldLoadExpansionROM() {
+    return loadExpansionROM;
+}
+
+std::filesystem::path EmulatorRunner::romFilePath() {
+    return romFile;
 }
 
 uint32_t EmulatorRunner::programCounter() {

--- a/src/EmulatorRunner.cpp
+++ b/src/EmulatorRunner.cpp
@@ -44,8 +44,7 @@ void EmulatorRunner::configure(int argc, char* argv[]) {
             logger.logError("The provided --exe filepath doesn't exist.");
         }
         argumentFound = true;
-    }
-    if (checkOption(argv, argv + argc, "--bin")) {
+    } else if (checkOption(argv, argv + argc, "--bin")) {
         char *path = getOptionValue(argv, argv + argc, "--bin");
         if (path == NULL) {
             logger.logError("Incorrect argument passed. See README.md for usage.");

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -299,6 +299,14 @@ void GPU::executeGp0(uint32_t value) {
                 };
                 break;
             }
+            case 0x4c: {
+                // TODO: validate opcode with documentation
+                gp0WordsRemaining = -1;
+                gp0InstructionMethod = [&]() {
+                    this->operationGp0MonochromePolylineOpaque();
+                };
+                break;
+            }
             case 0x50: {
                 gp0WordsRemaining = 4;
                 gp0InstructionMethod = [&]() {

--- a/src/Interconnect.cpp
+++ b/src/Interconnect.cpp
@@ -22,6 +22,8 @@ Interconnect::Interconnect(LogLevel logLevel, std::unique_ptr<COP0> &cop0, uniqu
     if (emulatorRunner->shouldRunTests()) {
         filesystem::path expansionFilePath = filesystem::current_path() / "expansion" / "EXPNSION.BIN";
         expansion1->loadBin(expansionFilePath);
+    } else if (emulatorRunner->shouldLoadExpansionROM()) {
+        expansion1->loadBin(emulatorRunner->romFilePath());
     }
 }
 

--- a/src/Interconnect.cpp
+++ b/src/Interconnect.cpp
@@ -1,6 +1,7 @@
 #include "Interconnect.hpp"
 #include "Range.hpp"
 #include "EmulatorRunner.hpp"
+#include "Interconnect.tcc"
 
 using namespace std;
 
@@ -24,6 +25,8 @@ Interconnect::Interconnect(LogLevel logLevel, std::unique_ptr<COP0> &cop0, uniqu
         expansion1->loadBin(expansionFilePath);
     } else if (emulatorRunner->shouldLoadExpansionROM()) {
         expansion1->loadBin(emulatorRunner->romFilePath());
+        uint32_t maskedAddress = maskRegion(0x1F020018);
+        store<uint32_t>(maskedAddress, 0x1);
     }
 }
 


### PR DESCRIPTION
Used to load cheat devices ROMs like `caetla` (SHA1: 115da354cae9f1dd66c6aeeefcd3ba714df9bc95):

![Screenshot from 2019-10-26 15 12 33@2x](https://user-images.githubusercontent.com/346590/67620337-f4607d80-f805-11e9-972c-51b2d358272e.png)
