### PR TITLE
Implement joypad controller

### DIFF
--- a/include/ConfigurationManager.hpp
+++ b/include/ConfigurationManager.hpp
@@ -8,6 +8,7 @@ class ConfigurationManager {
     Logger logger;
     std::string filePath;
 
+    std::string ctrllerName;
     bool resizeWindowToFitFramefuffer;
     bool showDebugInfoWindow;
 
@@ -19,6 +20,7 @@ class ConfigurationManager {
     LogLevel opengl;
     LogLevel dma;
     LogLevel spu;
+    LogLevel controller;
     bool trace;
 
     ConfigurationManager();
@@ -28,6 +30,7 @@ public:
     void setupConfigurationFile();
     void loadConfiguration();
 
+    std::string controllerName();
     bool shouldResizeWindowToFitFramebuffer();
     bool shouldShowDebugInfoWindow();
 
@@ -39,5 +42,6 @@ public:
     LogLevel openGLLogLevel();
     LogLevel dmaLogLevel();
     LogLevel spuLogLevel();
+    LogLevel controllerLogLevel();
     bool shouldTraceLogs();
 };

--- a/include/Controller.hpp
+++ b/include/Controller.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include "Logger.hpp"
 #include "DigitalController.hpp"
+#include "InterruptController.hpp"
 
 enum Device : uint8_t {
     NoDevice = 0x0,
@@ -151,6 +152,10 @@ union JoypadTxData {
 class Controller {
     Logger logger;
 
+    std::unique_ptr<InterruptController> &interruptController;
+    bool shouldCount;
+    uint32_t counter;
+
     std::unique_ptr<DigitalController> digitalController;
     Device currentDevice;
 
@@ -170,8 +175,10 @@ class Controller {
     uint32_t getStatusRegister();
     uint16_t getControlRegister();
 public:
-    Controller(LogLevel logLevel);
+    Controller(LogLevel logLevel, std::unique_ptr<InterruptController> &interruptController);
     ~Controller();
+
+    void step(uint32_t steps);
 
     template <typename T>
     inline T load(uint32_t offset);

--- a/include/Controller.hpp
+++ b/include/Controller.hpp
@@ -4,6 +4,12 @@
 #include "Logger.hpp"
 #include "DigitalController.hpp"
 
+enum Device : uint8_t {
+    NoDevice = 0x0,
+    ControllerDevice = 0x01,
+    MemoryCardDevice = 0x81
+};
+
 /*
 1F80104Ah JOY_CTRL (R/W) (usually 1003h,3003h,0000h)
 0     TX Enable (TXEN)  (0=Disable, 1=Enable)
@@ -149,6 +155,7 @@ public:
     ~Controller();
 
     std::unique_ptr<DigitalController> digitalController;
+    Device currentDevice;
 
     JoypadControl control;
     uint16_t joypadBaud;

--- a/include/Controller.hpp
+++ b/include/Controller.hpp
@@ -179,6 +179,7 @@ public:
     ~Controller();
 
     void step(uint32_t steps);
+    void updateInput();
 
     template <typename T>
     inline T load(uint32_t offset);

--- a/include/Controller.hpp
+++ b/include/Controller.hpp
@@ -143,7 +143,7 @@ union JoypadTxData {
 class Controller {
     Logger logger;
 public:
-    Controller();
+    Controller(LogLevel logLevel);
     ~Controller();
 
     JoypadControl control;

--- a/include/Controller.hpp
+++ b/include/Controller.hpp
@@ -150,9 +150,6 @@ union JoypadTxData {
 
 class Controller {
     Logger logger;
-public:
-    Controller(LogLevel logLevel);
-    ~Controller();
 
     std::unique_ptr<DigitalController> digitalController;
     Device currentDevice;
@@ -172,6 +169,9 @@ public:
     uint8_t getRxDataRegister();
     uint32_t getStatusRegister();
     uint16_t getControlRegister();
+public:
+    Controller(LogLevel logLevel);
+    ~Controller();
 
     template <typename T>
     inline T load(uint32_t offset);

--- a/include/Controller.hpp
+++ b/include/Controller.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <cstdint>
+#include <memory>
 #include "Logger.hpp"
+#include "DigitalController.hpp"
 
 /*
 1F80104Ah JOY_CTRL (R/W) (usually 1003h,3003h,0000h)
@@ -145,6 +147,8 @@ class Controller {
 public:
     Controller(LogLevel logLevel);
     ~Controller();
+
+    std::unique_ptr<DigitalController> digitalController;
 
     JoypadControl control;
     uint16_t joypadBaud;

--- a/include/DigitalController.hpp
+++ b/include/DigitalController.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "Logger.hpp"
+#include <SDL2/SDL.h>
+
+class DigitalController {
+    Logger logger;
+    SDL_Joystick *joystick;
+public:
+    DigitalController(LogLevel logLevel);
+    ~DigitalController();
+};

--- a/include/DigitalController.hpp
+++ b/include/DigitalController.hpp
@@ -32,4 +32,5 @@ public:
 
     uint8_t getResponse(uint8_t value);
     CommunicationSequenceStage getCurrentStage();
+    bool getAcknowledge();
 };

--- a/include/DigitalController.hpp
+++ b/include/DigitalController.hpp
@@ -1,11 +1,35 @@
 #pragma once
+#include <cstdint>
 #include "Logger.hpp"
 #include <SDL2/SDL.h>
+
+/*
+Controller Communication Sequence
+Send Reply Comment
+01h  Hi-Z  Controller Access (unlike 81h=Memory Card access), dummy response
+42h  idlo  Receive ID bit0..7 (variable) and Send Read Command (ASCII "B")
+TAP  idhi  Receive ID bit8..15 (usually/always 5Ah)
+MOT  swlo  Receive Digital Switches bit0..7
+MOT  swhi  Receive Digital Switches bit8..15
+--- transfer stops here for digital pad (or analog pad in digital mode) ---
+*/
+enum CommunicationSequenceStage : uint8_t {
+    ControllerAccess = 0,
+    ReceiveIDLow = 1,
+    ReceiveIDHigh = 2,
+    ReceiveDigitalSwitchesLow = 3,
+    ReceiveDigitalSwitchesHigh = 4,
+};
 
 class DigitalController {
     Logger logger;
     SDL_Joystick *joystick;
+    CommunicationSequenceStage currentStage;
+    uint16_t identifier;
 public:
     DigitalController(LogLevel logLevel);
     ~DigitalController();
+
+    uint8_t getResponse(uint8_t value);
+    CommunicationSequenceStage getCurrentStage();
 };

--- a/include/DigitalController.hpp
+++ b/include/DigitalController.hpp
@@ -4,6 +4,57 @@
 #include <SDL2/SDL.h>
 
 /*
+Standard Controllers
+__Halfword 0 (Controller Info)_______________________________________________
+0-15  Controller Info  (5A41h=digital, 5A73h=analog/pad, 5A53h=analog/stick)
+__Halfword 1 (Digital Switches)______________________________________________
+0   Select Button    (0=Pressed, 1=Released)
+1   L3/Joy-button    (0=Pressed, 1=Released/None/Disabled) ;analog mode only
+2   R3/Joy-button    (0=Pressed, 1=Released/None/Disabled) ;analog mode only
+3   Start Button     (0=Pressed, 1=Released)
+4   Joypad Up        (0=Pressed, 1=Released)
+5   Joypad Right     (0=Pressed, 1=Released)
+6   Joypad Down      (0=Pressed, 1=Released)
+7   Joypad Left      (0=Pressed, 1=Released)
+8   L2 Button        (0=Pressed, 1=Released) (Lower-left shoulder)
+9   R2 Button        (0=Pressed, 1=Released) (Lower-right shoulder)
+10  L1 Button        (0=Pressed, 1=Released) (Upper-left shoulder)
+11  R1 Button        (0=Pressed, 1=Released) (Upper-right shoulder)
+12  /\ Button        (0=Pressed, 1=Released) (Triangle, upper button)
+13  () Button        (0=Pressed, 1=Released) (Circle, right button)
+14  >< Button        (0=Pressed, 1=Released) (Cross, lower button)
+15  [] Button        (0=Pressed, 1=Released) (Square, left button)
+*/
+union DigitalControllerSwitches {
+    struct {
+        uint16_t select : 1;
+        uint16_t L3 : 1;
+        uint16_t R3 : 1;
+        uint16_t start : 1;
+        uint16_t up : 1;
+        uint16_t right : 1;
+        uint16_t down : 1;
+        uint16_t left : 1;
+        uint16_t L2 : 1;
+        uint16_t R2 : 1;
+        uint16_t L1 : 1;
+        uint16_t R1 : 1;
+        uint16_t triangle : 1;
+        uint16_t circle : 1;
+        uint16_t x : 1;
+        uint16_t square : 1;
+    };
+
+    uint16_t _value;
+
+    DigitalControllerSwitches() : _value(0xFFFF) {}
+
+    void reset() {
+        _value = 0xFFFF;
+    }
+};
+
+/*
 Controller Communication Sequence
 Send Reply Comment
 01h  Hi-Z  Controller Access (unlike 81h=Memory Card access), dummy response
@@ -26,6 +77,7 @@ class DigitalController {
     SDL_Joystick *joystick;
     CommunicationSequenceStage currentStage;
     uint16_t identifier;
+    DigitalControllerSwitches switches;
 public:
     DigitalController(LogLevel logLevel);
     ~DigitalController();
@@ -33,4 +85,5 @@ public:
     uint8_t getResponse(uint8_t value);
     CommunicationSequenceStage getCurrentStage();
     bool getAcknowledge();
+    void updateInput();
 };

--- a/src/ConfigurationManager.cpp
+++ b/src/ConfigurationManager.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 const string configurationFile = "config.yaml";
 
-ConfigurationManager::ConfigurationManager() : logger(LogLevel::Warning, "", false), filePath(), resizeWindowToFitFramefuffer(false), showDebugInfoWindow(false),  bios(NoLog), cdrom(NoLog), interconnect(NoLog), cpu(NoLog), gpu(NoLog), opengl(NoLog), dma(NoLog), trace(false) {}
+ConfigurationManager::ConfigurationManager() : logger(LogLevel::Warning, "", false), filePath(), ctrllerName(""), resizeWindowToFitFramefuffer(false), showDebugInfoWindow(false),  bios(NoLog), cdrom(NoLog), interconnect(NoLog), cpu(NoLog), gpu(NoLog), opengl(NoLog), dma(NoLog), controller(NoLog), trace(false) {}
 
 ConfigurationManager* ConfigurationManager::instance = nullptr;
 
@@ -57,10 +57,12 @@ void ConfigurationManager::setupConfigurationFile() {
     logConfigurationRef["opengl"] = "NOLOG";
     logConfigurationRef["dma"] = "NOLOG";
     logConfigurationRef["spu"] = "NOLOG";
+    logConfiguration["controller"] = "NOLOG";
     logConfigurationRef["trace"] = "false";
     Yaml::Node configuration = Yaml::Node();
     Yaml::Node &configurationRef = configuration;
     configurationRef["log"] = logConfiguration;
+    configurationRef["controllerName"] = "Sony Interactive Entertainment Controller";
     configurationRef["debugInfoWindow"] = "false";
     configurationRef["showFramebuffer"] = "false";
     Yaml::Serialize(configuration, globalConfigurationPath.c_str());
@@ -70,6 +72,7 @@ void ConfigurationManager::setupConfigurationFile() {
 void ConfigurationManager::loadConfiguration() {
     Yaml::Node configuration = Yaml::Node();
     Yaml::Parse(configuration, filePath.c_str());
+    ctrllerName = configuration["controllerName"].As<string>();
     resizeWindowToFitFramefuffer = configuration["showFramebuffer"].As<bool>();
     showDebugInfoWindow = configuration["debugInfoWindow"].As<bool>();
     bios = logLevelWithValue(configuration["log"]["bios"].As<string>());
@@ -80,10 +83,15 @@ void ConfigurationManager::loadConfiguration() {
     opengl = logLevelWithValue(configuration["log"]["opengl"].As<string>());
     dma = logLevelWithValue(configuration["log"]["dma"].As<string>());
     spu = logLevelWithValue(configuration["log"]["spu"].As<string>());
+    controller = logLevelWithValue(configuration["log"]["controller"].As<string>());
     trace = configuration["log"]["trace"].As<bool>();
     if (trace) {
         remove("ruby.log");
     }
+}
+
+std::string ConfigurationManager::controllerName() {
+    return ctrllerName;
 }
 
 bool ConfigurationManager::shouldResizeWindowToFitFramebuffer() {
@@ -124,6 +132,10 @@ LogLevel ConfigurationManager::dmaLogLevel() {
 
 LogLevel ConfigurationManager::spuLogLevel() {
     return spu;
+}
+
+LogLevel ConfigurationManager::controllerLogLevel() {
+    return controller;
 }
 
 bool ConfigurationManager::shouldTraceLogs() {

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -100,3 +100,7 @@ void Controller::step(uint32_t steps) {
         interruptController->trigger(InterruptRequestNumber::CONTROLLER);
     }
 }
+
+void Controller::updateInput() {
+    digitalController->updateInput();
+}

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1,6 +1,6 @@
 #include "Controller.hpp"
 
-Controller::Controller() : logger(LogLevel::NoLog), control(), joypadBaud(), mode(), rxData(), status(), txData() {
+Controller::Controller(LogLevel logLevel) : logger(logLevel), control(), joypadBaud(), mode(), rxData(), status(), txData() {
 
 }
 

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -1,6 +1,8 @@
 #include "Controller.hpp"
 
-Controller::Controller(LogLevel logLevel) : logger(logLevel), control(), joypadBaud(), mode(), rxData(), status(), txData() {
+using namespace std;
+
+Controller::Controller(LogLevel logLevel) : logger(logLevel), digitalController(make_unique<DigitalController>(logLevel)), control(), joypadBaud(), mode(), rxData(), status(), txData() {
 
 }
 

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -2,7 +2,16 @@
 
 using namespace std;
 
-Controller::Controller(LogLevel logLevel) : logger(logLevel), digitalController(make_unique<DigitalController>(logLevel)), currentDevice(NoDevice), control(), joypadBaud(), mode(), rxData(), status(), txData() {
+/*
+IRQ7 is usually triggered circa 1500 cycles after sending a byte (counted from the begin of
+the first bit), except, the last byte doesn't trigger IRQ7, and, after the 7th byte of the
+Read command, an additional delay of circa 31000 cycles occurs before IRQ7 gets triggered
+(that strange extra delay occurs only on original Sony cards, not on cards from other
+manufacturers).
+*/
+const uint32_t SystemClocksPerControllerInt7 = 1500;
+
+Controller::Controller(LogLevel logLevel, std::unique_ptr<InterruptController> &interruptController) : logger(logLevel), interruptController(interruptController), digitalController(make_unique<DigitalController>(logLevel)), currentDevice(NoDevice), control(), joypadBaud(), mode(), rxData(), status(), txData() {
 
 }
 
@@ -12,6 +21,9 @@ Controller::~Controller() {
 
 void Controller::setControlRegister(uint16_t value) {
     control._value = value;
+    if (control.acknowledge) {
+        status.interruptRequest = false;
+    }
 }
 
 void Controller::setJoypadBaudRegister(uint16_t value) {
@@ -45,6 +57,11 @@ void Controller::setTxDataRegister(uint8_t value) {
             return;
         } else {
             rxData.receivedData = digitalController->getResponse(value);
+            status.ackInputLevel = digitalController->getAcknowledge();
+            if (status.ackInputLevel) {
+                shouldCount = true;
+                counter = 0;
+            }
             if (digitalController->getCurrentStage() == CommunicationSequenceStage::ControllerAccess) {
                 currentDevice = NoDevice;
             }
@@ -67,4 +84,19 @@ uint32_t Controller::getStatusRegister() {
 
 uint16_t Controller::getControlRegister() {
     return control._value;
+}
+
+void Controller::step(uint32_t steps) {
+    if (shouldCount) {
+        counter += steps;
+        if (counter >= SystemClocksPerControllerInt7) {
+            status.interruptRequest = true;
+            status.ackInputLevel = false;
+            shouldCount = false;
+            counter = 0;
+        }
+    }
+    if (status.interruptRequest) {
+        interruptController->trigger(InterruptRequestNumber::CONTROLLER);
+    }
 }

--- a/src/DigitalController.cpp
+++ b/src/DigitalController.cpp
@@ -1,0 +1,39 @@
+#include "DigitalController.hpp"
+#include "ConfigurationManager.hpp"
+#include <string>
+
+using namespace std;
+
+DigitalController::DigitalController(LogLevel logLevel) : logger(logLevel) {
+    ConfigurationManager *configurationManager = ConfigurationManager::getInstance();
+    string controllerName = configurationManager->controllerName();
+    int numberOfJoysticks = SDL_NumJoysticks();
+    if (numberOfJoysticks < 0) {
+        logger.logError("Error getting number of joysticks: %s", SDL_GetError());
+    }
+    for(int i = 0; i < numberOfJoysticks; i++) {
+        SDL_Joystick *currentJoystick = SDL_JoystickOpen(i);
+        std::string joystickName = SDL_JoystickName(currentJoystick);
+        if (joystickName.compare(controllerName) == 0) {
+            joystick = currentJoystick;
+            break;
+        }
+    }
+    if (joystick == nullptr) {
+        logger.logError("Failed to find target controller.");
+    }
+    int numberOfButtons = SDL_JoystickNumButtons(joystick);
+    logger.logMessage("Buttons in joystick: %d buttons", numberOfButtons);
+    if (numberOfButtons < 0) {
+        logger.logError("Error getting number of buttons: %s", SDL_GetError());
+    }
+    int numberOfAxes = SDL_JoystickNumAxes(joystick);
+    logger.logMessage("Axes in joystick: %d buttons", numberOfAxes);
+    if (numberOfAxes < 0) {
+        logger.logError("Error getting number of axes: %s", SDL_GetError());
+    }
+}
+
+DigitalController::~DigitalController() {
+
+}

--- a/src/DigitalController.cpp
+++ b/src/DigitalController.cpp
@@ -80,3 +80,7 @@ uint8_t DigitalController::getResponse(uint8_t value) {
 CommunicationSequenceStage DigitalController::getCurrentStage() {
     return currentStage;
 }
+
+bool DigitalController::getAcknowledge() {
+    return currentStage != ControllerAccess;
+}

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -107,7 +107,7 @@ void Emulator::dumpRAM() {
 }
 
 void Emulator::setupSDL() {
-    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) != 0) {
         logger.logError("Error initializing SDL: %s", SDL_GetError());
     }
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -40,7 +40,7 @@ Emulator::Emulator() : logger(LogLevel::NoLog), ttyBuffer(), biosFunctionsLog() 
     timer0 = make_unique<Timer0>();
     timer1 = make_unique<Timer1>();
     timer2 = make_unique<Timer2>();
-    controller = make_unique<Controller>(configurationManager->controllerLogLevel());
+    controller = make_unique<Controller>(configurationManager->controllerLogLevel(), interruptController);
     spu = make_unique<SPU>(configurationManager->spuLogLevel());
     interconnect = make_unique<Interconnect>(configurationManager->interconnectLogLevel(), cop0, bios, ram, gpu, dma, scratchpad, cdrom, interruptController, expansion1, timer0, timer1, timer2, controller, spu);
     cpu = make_unique<CPU>(configurationManager->cpuLogLevel(), interconnect, cop0, logBiosFunctionCalls);
@@ -73,6 +73,7 @@ void Emulator::emulateFrame() {
         }
         dma->step();
         cdrom->step();
+        controller->step(systemClockStep);
         timer0->step(systemClockStep);
         timer1->step(systemClockStep);
         timer2->step(systemClockStep);

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -40,7 +40,7 @@ Emulator::Emulator() : logger(LogLevel::NoLog), ttyBuffer(), biosFunctionsLog() 
     timer0 = make_unique<Timer0>();
     timer1 = make_unique<Timer1>();
     timer2 = make_unique<Timer2>();
-    controller = make_unique<Controller>();
+    controller = make_unique<Controller>(configurationManager->controllerLogLevel());
     spu = make_unique<SPU>(configurationManager->spuLogLevel());
     interconnect = make_unique<Interconnect>(configurationManager->interconnectLogLevel(), cop0, bios, ram, gpu, dma, scratchpad, cdrom, interruptController, expansion1, timer0, timer1, timer2, controller, spu);
     cpu = make_unique<CPU>(configurationManager->cpuLogLevel(), interconnect, cop0, logBiosFunctionCalls);

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -53,6 +53,7 @@ CPU* Emulator::getCPU() {
 }
 
 void Emulator::emulateFrame() {
+    controller->updateInput();
     // Emulate cpu for given time slice (21 * magicNumber cycles),
     // then check what events occured during that time slice,
     // finally simulate rest of hardware to accommodate for that


### PR DESCRIPTION
This is a continuation of #20. USB controller input is supported now with some limitations:

* The USB controller can be selected by name using the `controllerName` configuration key, but it has to have the same button mapping as the [PlayStation Classic](https://www.playstation.com/en-us/explore/playstation-classic/) USB controller: 10 buttons and 2 axes.
* Only 1 controller is supported.
* Only 1 controller type is supported: digital (the first generation, without the analog sticks).

[PeterLemon/PSX Cube demo](https://github.com/PeterLemon/PSX/tree/master/Cube):

![file](https://user-images.githubusercontent.com/346590/69101762-bf3ff780-0a60-11ea-8ffa-92733495a166.gif)

