### PR TITLE
Make Puzzle Bobble 2 boot

### DIFF
--- a/include/CDImage.hpp
+++ b/include/CDImage.hpp
@@ -4,9 +4,7 @@
 #include <cstdint>
 #include <filesystem>
 #include "Logger.hpp"
-
-const uint32_t SecondsPerMinute = 60;
-const uint32_t SectorsPerSecond = 75;
+#include "Constants.h"
 
 /*
 Mode2/Form1 (CD-XA)
@@ -31,10 +29,12 @@ struct CDSector {
 class CDImage {
     std::ifstream file;
     Logger logger;
+    unsigned int logicalBlockAddressing;
 public:
     CDImage();
     ~CDImage();
 
     void open(std::filesystem::path filePath);
     CDSector readSector(uint32_t location);
+    unsigned int getLBA();
 };

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -331,7 +331,7 @@ public:
     CDROM(LogLevel logLevel, std::unique_ptr<InterruptController> &interruptController);
     ~CDROM();
 
-    void step();
+    void step(uint32_t cycles);
 
     template <typename T>
     inline T load(uint32_t offset);

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -323,6 +323,7 @@ Command          Parameters      Response(s)
     void operationDemute();
     void operationGetTN();
     void operationReadS();
+    void operationGetTD();
 
     void handleUnsupportedOperation(uint8_t operation);
 public:

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -322,6 +322,7 @@ Command          Parameters      Response(s)
     void operationInit();
     void operationDemute();
     void operationGetTN();
+    void operationReadS();
 
     void handleUnsupportedOperation(uint8_t operation);
 public:

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -324,6 +324,7 @@ Command          Parameters      Response(s)
     void operationGetTN();
     void operationReadS();
     void operationGetTD();
+    void operationStop();
 
     void handleUnsupportedOperation(uint8_t operation);
 public:

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -325,6 +325,7 @@ Command          Parameters      Response(s)
     void operationReadS();
     void operationGetTD();
     void operationStop();
+    void operationSeekP();
 
     void handleUnsupportedOperation(uint8_t operation);
 public:

--- a/include/CDROM.hpp
+++ b/include/CDROM.hpp
@@ -321,6 +321,7 @@ Command          Parameters      Response(s)
     void operationPause();
     void operationInit();
     void operationDemute();
+    void operationGetTN();
 
     void handleUnsupportedOperation(uint8_t operation);
 public:

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -10,3 +10,5 @@ const uint32_t VideoSystemClocksPerScanline = 3413;
 const uint32_t VideoSystemClocksPerDot = 6;
 const uint32_t ScanlinesPerFrame = 263;
 const std::string EmulatorName = "ルビィ";
+const uint32_t SecondsPerMinute = 60;
+const uint32_t SectorsPerSecond = 75;

--- a/include/DigitalController.hpp
+++ b/include/DigitalController.hpp
@@ -70,6 +70,7 @@ enum CommunicationSequenceStage : uint8_t {
     ReceiveIDHigh = 2,
     ReceiveDigitalSwitchesLow = 3,
     ReceiveDigitalSwitchesHigh = 4,
+    TransferStopped = 5,
 };
 
 class DigitalController {

--- a/include/Helpers.hpp
+++ b/include/Helpers.hpp
@@ -2,7 +2,10 @@
 #include <string>
 #include <cstdint>
 #include <filesystem>
+#include <tuple>
 
 void readBinary(const std::filesystem::path& filePath, uint8_t *data, uint32_t atOrigin, int64_t size);
 void readBinary(const std::filesystem::path& filePath, uint8_t *data);
 uint8_t decimalFromBCDEncodedInt(uint8_t bcdEncoded);
+std::tuple<uint8_t, uint8_t, uint8_t> minutesSecondsSectorsFromLogicalABlockddressing(unsigned int lba);
+uint8_t BCDEncodedIntFromDecimal(unsigned int decimal);

--- a/include/Interconnect.hpp
+++ b/include/Interconnect.hpp
@@ -34,6 +34,7 @@ const Range dmaRegisterRange = Range(0x1f801080, 0x80);
 const Range gpuRegisterRange = Range(0x1f801810, 8);
 const Range cdromRegisterRange = Range(0x1f801800, 4);
 const Range controllerRegisterRange = Range(0x1f801040, 16);
+const Range mdecRegisterRange = Range(0x1F801820, 8);
 
 /*
 Memory Map

--- a/include/Interconnect.tcc
+++ b/include/Interconnect.tcc
@@ -84,6 +84,11 @@ inline T Interconnect::load(uint32_t address) const {
     if (debugger->isAttached()) {
         return 0;
     }
+    offset = mdecRegisterRange.contains(absoluteAddress);
+    if (offset) {
+        logger.logWarning("Unhandled MDEC read at offset: %#x", *offset);
+        return 0;
+    }
     logger.logError("Unhandled read at: %#x", address);
     return 0;
 }
@@ -196,6 +201,11 @@ inline void Interconnect::store(uint32_t address, T value) const {
     offset = controllerRegisterRange.contains(absoluteAddress);
     if (offset) {
         controller->store<T>(*offset, value);
+        return;
+    }
+    offset = mdecRegisterRange.contains(absoluteAddress);
+    if (offset) {
+        logger.logWarning("Unhandled MDEC write at offset: %#x", *offset);
         return;
     }
     logger.logError("Unhandled write at: %#x", address);

--- a/src/CDImage.cpp
+++ b/src/CDImage.cpp
@@ -2,7 +2,7 @@
 
 using namespace std;
 
-CDImage::CDImage() : file(), logger(LogLevel::NoLog) {
+CDImage::CDImage() : file(), logger(LogLevel::NoLog), logicalBlockAddressing(0) {
 }
 
 CDImage::~CDImage() {
@@ -10,10 +10,14 @@ CDImage::~CDImage() {
 }
 
 void CDImage::open(std::filesystem::path filePath) {
-    file.open(filePath, ios::binary);
+    file.open(filePath, ios::binary | ios::ate);
     if (!file.is_open()) {
         logger.logError("Unable to load CD-ROM image file");
     }
+    std::streampos size = file.tellg();
+    file.seekg(0, ios::beg);
+    int sectorSize = sizeof(CDSector);
+    logicalBlockAddressing = size / sectorSize;
 }
 
 CDSector CDImage::readSector(uint32_t location) {
@@ -24,4 +28,8 @@ CDSector CDImage::readSector(uint32_t location) {
     file.seekg(location * sizeof(CDSector), file.beg);
     file.read(reinterpret_cast<char *>(&sector), sizeof(sector));
     return sector;
+}
+
+unsigned int CDImage::getLBA() {
+    return logicalBlockAddressing;
 }

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -128,6 +128,10 @@ void CDROM::execute(uint8_t value) {
             operationSetmode();
             break;
         }
+        case 0x13: {
+            operationGetTN();
+            break;
+        }
         case 0x15: {
             operationSeekL();
             break;
@@ -446,6 +450,20 @@ void CDROM::operationDemute() {
     interruptQueue.push(INT3);
 
     logger.logMessage("CMD Demute");
+}
+
+/*
+GetTN - Command 13h --> INT3(stat,first,last) ;BCD
+*/
+void CDROM::operationGetTN() {
+    // TODO: CUE parser
+
+    pushResponse(statusCode._value);
+    pushResponse(0x1);
+    pushResponse(0x1);
+    interruptQueue.push(INT3);
+
+    logger.logMessage("CMD GetTN");
 }
 
 void CDROM::handleUnsupportedOperation(uint8_t operation) {

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -112,6 +112,10 @@ void CDROM::execute(uint8_t value) {
             operationReadN();
             break;
         }
+        case 0x08: {
+            operationStop();
+            break;
+        }
         case 0x09: {
             operationPause();
             break;
@@ -515,6 +519,21 @@ void CDROM::operationGetTD() {
     interruptQueue.push(INT3);
 
     logger.logMessage("CMD GetTD");
+}
+
+/*
+Stop - Command 08h --> INT3(stat) --> INT2(stat)
+*/
+void CDROM::operationStop() {
+    statusCode._value = 0;
+
+    pushResponse(statusCode._value);
+    interruptQueue.push(INT3);
+
+    pushResponse(statusCode._value);
+    interruptQueue.push(INT2);
+
+    logger.logMessage("CMD Stop");
 }
 
 void CDROM::handleUnsupportedOperation(uint8_t operation) {

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -132,6 +132,10 @@ void CDROM::execute(uint8_t value) {
             operationGetTN();
             break;
         }
+        case 0x14: {
+            operationGetTD();
+            break;
+        }
         case 0x15: {
             operationSeekL();
             break;
@@ -482,6 +486,35 @@ void CDROM::operationReadS() {
     interruptQueue.push(INT3);
 
     logger.logMessage("CMD ReadS");
+}
+
+/*
+GetTD - Command 14h,track --> INT3(stat,mm,ss) ;BCD
+*/
+void CDROM::operationGetTD() {
+    // TODO: CUE parser
+
+    uint8_t param = parameters.front();
+    parameters.pop();
+
+    uint8_t track = decimalFromBCDEncodedInt(param);
+    if (track == 0) {
+        uint8_t minutes;
+        uint8_t seconds;
+        uint8_t sectors;
+        tie(minutes, seconds, sectors) = minutesSecondsSectorsFromLogicalABlockddressing(image.getLBA());
+        pushResponse(statusCode._value);
+        pushResponse(BCDEncodedIntFromDecimal(minutes));
+        pushResponse(BCDEncodedIntFromDecimal(seconds));
+    } else {
+        pushResponse(statusCode._value);
+        pushResponse(0x0);
+        pushResponse(0x2);
+    }
+
+    interruptQueue.push(INT3);
+
+    logger.logMessage("CMD GetTD");
 }
 
 void CDROM::handleUnsupportedOperation(uint8_t operation) {

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -145,6 +145,10 @@ void CDROM::execute(uint8_t value) {
             operationSeekL();
             break;
         }
+        case 0x16: {
+            operationSeekP();
+            break;
+        }
         case 0x19: {
             operationTest();
             break;
@@ -392,6 +396,23 @@ void CDROM::operationSeekL() {
     interruptQueue.push(INT2);
 
     logger.logMessage("CMD SeekL");
+}
+
+/*
+SeekP - Command 16h --> INT3(stat) --> INT2(stat)
+*/
+void CDROM::operationSeekP() {
+    readSector = seekSector;
+
+    pushResponse(statusCode._value);
+    interruptQueue.push(INT3);
+
+    statusCode.setState(CDROMState::Seeking);
+
+    pushResponse(statusCode._value);
+    interruptQueue.push(INT2);
+
+    logger.logMessage("CMD SeekP");
 }
 
 /*

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -144,6 +144,10 @@ void CDROM::execute(uint8_t value) {
             operationGetID();
             break;
         }
+        case 0x1B: {
+            operationReadS();
+            break;
+        }
         default: {
             handleUnsupportedOperation(value);
         }
@@ -464,6 +468,20 @@ void CDROM::operationGetTN() {
     interruptQueue.push(INT3);
 
     logger.logMessage("CMD GetTN");
+}
+
+/*
+ReadS - Command 1Bh --> INT3(stat) --> INT1(stat) --> datablock
+*/
+void CDROM::operationReadS() {
+    readSector = seekSector;
+
+    statusCode.setState(CDROMState::Reading);
+
+    pushResponse(statusCode._value);
+    interruptQueue.push(INT3);
+
+    logger.logMessage("CMD ReadS");
 }
 
 void CDROM::handleUnsupportedOperation(uint8_t operation) {

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -60,9 +60,10 @@ void Controller::setTxDataRegister(uint8_t value) {
             rxData.receivedData = 0xff;
             return;
         } else {
-            rxData.receivedData = digitalController->getResponse(value);
-            status.ackInputLevel = digitalController->getAcknowledge();
-            if (status.ackInputLevel) {
+            rxData.receivedData = digitalController->getResponse(value);;
+            control.acknowledge = digitalController->getAcknowledge();
+            status.ackInputLevel = true;
+            if (control.acknowledge) {
                 shouldCount = true;
                 counter = 0;
             }

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -53,11 +53,13 @@ void Controller::setTxDataRegister(uint8_t value) {
     if (currentDevice == Device::MemoryCardDevice) {
         // TODO: Implement memory card
         rxData.receivedData = 0xff;
+        currentDevice = NoDevice;
         return;
     } else if (currentDevice == Device::ControllerDevice) {
         if (control.desiredSlotNumber == 1) {
             // TODO: Implement controller 2
             rxData.receivedData = 0xff;
+            currentDevice = NoDevice;
             return;
         } else {
             rxData.receivedData = digitalController->getResponse(value);;

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -82,7 +82,7 @@ uint8_t Controller::getRxDataRegister() {
 uint32_t Controller::getStatusRegister() {
     logger.logMessage("JOY_STAT [R]: %#x", status._value);
     status.txReadyFlag1 = true;
-    status.txReadyFlag1 = true;
+    status.txReadyFlag2 = true;
     uint32_t value = status._value;
     status.ackInputLevel = false;
     return value;

--- a/src/DMA.cpp
+++ b/src/DMA.cpp
@@ -152,6 +152,11 @@ void DMA::executeBlock(DMAPort port, Channel& channel) {
                         goto unhandled;
                         break;
                     }
+                    case DMAPort::MDECin: {
+                        logger.logWarning("Unhandled DMA block transfer from RAM to source port: %s", portDescription(port).c_str());
+                        goto unhandled;
+                        break;
+                    }
                     default: {
                         logger.logError("Unhandled DMA block transfer from RAM to source port: %s", portDescription(port).c_str());
                         break;

--- a/src/DigitalController.cpp
+++ b/src/DigitalController.cpp
@@ -70,8 +70,12 @@ uint8_t DigitalController::getResponse(uint8_t value) {
         }
         case ReceiveDigitalSwitchesHigh: {
             // TODO: Handle MOT validation?
-            currentStage = ControllerAccess;
+            currentStage = TransferStopped;
             return switches._value >> 8;
+        }
+        case TransferStopped: {
+            currentStage = ControllerAccess;
+            return 0xff;
         }
     }
     return 0x0;

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -66,7 +66,7 @@ void Emulator::emulateFrame() {
             totalSystemClocksThisFrame++;
         }
         dma->step();
-        cdrom->step();
+        cdrom->step(systemClockStep);
         controller->step(systemClockStep);
         timer0->step(systemClockStep);
         timer1->step(systemClockStep);

--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include "Output.hpp"
 #include <iostream>
+#include "Constants.h"
 
 using namespace std;
 
@@ -32,4 +33,22 @@ uint8_t decimalFromBCDEncodedInt(uint8_t bcdEncoded) {
 
     uint8_t value = high * 10 + low;
     return value;
+}
+
+tuple<uint8_t, uint8_t, uint8_t> minutesSecondsSectorsFromLogicalABlockddressing(unsigned int lba) {
+    uint8_t sectors = lba % SectorsPerSecond;
+    lba /= SectorsPerSecond;
+
+    uint8_t seconds = lba % SecondsPerMinute;
+    lba /= SecondsPerMinute;
+
+    uint8_t minutes = lba;
+
+    return { minutes, seconds, sectors };
+}
+
+uint8_t BCDEncodedIntFromDecimal(unsigned int decimal) {
+    uint8_t high = decimal / 10;
+    uint8_t low = decimal % 10;
+    return high | low;
 }


### PR DESCRIPTION
Puzzle Bobble 2 is one of the first PlayStation games (a port from arcade games). Presumably it doesn't require timers and it's generally speaking the first game you should aim to boot. The changes made here were picked one by one by reading warning logs:

* Add missing CDROM operations: GetTN, ReadS, GetTD, Stop and SeekP.
* Use system clock to keep CDROM in sync.
* Various fixes to controller: the most important one is https://github.com/UnsafePointer/ruby/commit/98d46c7eca87b4f0124c3779cd08534944072b69.
* Allow read and writes in MDEC registries address space.
* Handle MDEC DMA transfer: doesn't do anything.

![output](https://user-images.githubusercontent.com/346590/77846930-b4893200-71b9-11ea-9182-bc4dc636844c.gif)
