### PR TITLE
Implement GTE commands

### DIFF
--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -156,4 +156,5 @@ public:
     void colorDepthQue(GTEInstruction instruction);
     void normalColorDepthCueSingleVector(GTEInstruction instruction, unsigned int index);
     void normalColorDepthCueTripleVector(GTEInstruction instruction);
+    void depthCueColorLight(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -142,4 +142,5 @@ public:
     void averageOfFourZValues(GTEInstruction instruction);
     void outerProductOfTwoVectors(GTEInstruction instruction);
     void generalPurposeInterpolationGPF(GTEInstruction instruction);
+    void generalPurposeInterpolationGPL(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -152,4 +152,5 @@ public:
     void colorColor(GTEInstruction instruction);
     void depthCueingDPCS(GTEInstruction instruction, bool useFIFO);
     void depthCueingDPCT(GTEInstruction instruction);
+    void interpolationOfVectorAndFarColorVector(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -150,4 +150,5 @@ public:
     void normalColorColorSingleVector(GTEInstruction instruction, unsigned int index);
     void normalColorColorTripleVector(GTEInstruction instruction);
     void colorColor(GTEInstruction instruction);
+    void depthCueing(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include "Logger.hpp"
 #include "GTEInstruction.hpp"
+#include "GTEFlagRegister.hpp"
 
 struct GTEVector3_16_t {
     int16_t x;
@@ -46,60 +47,6 @@ struct GTEVector3_32_t {
 struct GTEVector2_32_t {
     int32_t x;
     int32_t y;
-};
-
-/*
-cop2r63 (cnt31) - FLAG - Returns any calculation errors.
-0-11 Not used (always zero) (Read only)
-12   IR0 saturated to +0000h..+1000h
-13   SY2 saturated to -0400h..+03FFh
-14   SX2 saturated to -0400h..+03FFh
-15   MAC0 Result larger than 31 bits and negative
-16   MAC0 Result larger than 31 bits and positive
-17   Divide overflow. RTPS/RTPT division result saturated to max=1FFFFh
-18   SZ3 or OTZ saturated to +0000h..+FFFFh
-19   Color-FIFO-B saturated to +00h..+FFh
-20   Color-FIFO-G saturated to +00h..+FFh
-21   Color-FIFO-R saturated to +00h..+FFh
-22   IR3 saturated to +0000h..+7FFFh (lm=1) or to -8000h..+7FFFh (lm=0)
-23   IR2 saturated to +0000h..+7FFFh (lm=1) or to -8000h..+7FFFh (lm=0)
-24   IR1 saturated to +0000h..+7FFFh (lm=1) or to -8000h..+7FFFh (lm=0)
-25   MAC3 Result larger than 43 bits and negative
-26   MAC2 Result larger than 43 bits and negative
-27   MAC1 Result larger than 43 bits and negative
-28   MAC3 Result larger than 43 bits and positive
-29   MAC2 Result larger than 43 bits and positive
-30   MAC1 Result larger than 43 bits and positive
-31   Error Flag (Bit30..23, and 18..13 ORed together) (Read only)
-*/
-union GTEFLAGRegister {
-    struct {
-        uint32_t unused : 12;
-        uint32_t ir0 : 1;
-        uint32_t sy2 : 1;
-        uint32_t sx2 : 1;
-        uint32_t mac0Negative : 1;
-        uint32_t mac0Positive : 1;
-        uint32_t divideOverflow : 1;
-        uint32_t sz3OrOtz : 1;
-        uint32_t colorFifoB : 1;
-        uint32_t colorFifoG : 1;
-        uint32_t colorFifoR : 1;
-        uint32_t ir3 : 1;
-        uint32_t ir2 : 1;
-        uint32_t ir1 : 1;
-        uint32_t mac3Negative : 1;
-        uint32_t mac2Negative : 1;
-        uint32_t mac1Negative : 1;
-        uint32_t mac3Positive : 1;
-        uint32_t mac2Positive : 1;
-        uint32_t mac1Positive : 1;
-        uint32_t error : 1;
-    };
-
-    uint32_t _value;
-
-    GTEFLAGRegister() : _value(0) {}
 };
 
 /*
@@ -178,7 +125,7 @@ class GTE {
     int32_t dqb; // cop2r60
     int16_t zsf3; // cop2r61
     int16_t zsf4; // cop2r62
-    GTEFLAGRegister flag; // cop2r63
+    GTEFlagRegister flag; // cop2r63
 public:
     GTE(LogLevel logLevel);
     ~GTE();
@@ -188,11 +135,6 @@ public:
     void setControl(uint32_t index, uint32_t value);
     uint32_t getControl(uint32_t index);
     void execute(uint32_t value);
-
-    int64_t calculateMAC(unsigned int index, int64_t value);
-    int32_t calculateMAC0(int64_t value);
-    int16_t calculateIR(unsigned int index, int64_t value, bool lm);
-    uint16_t calculateSZ3(int64_t value);
 
     void squareVector(GTEInstruction instruction);
     void normalClipping(GTEInstruction instruction);

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -145,5 +145,6 @@ public:
     void generalPurposeInterpolationGPL(GTEInstruction instruction);
     void perspectiveTransformation(GTEInstruction instruction, unsigned int index);
     void perspectiveTransformationOnThreePoints(GTEInstruction instruction);
-    void normalColor(GTEInstruction instruction);
+    void normalColorNCS(GTEInstruction instruction, unsigned int index);
+    void normalColorNCT(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -145,4 +145,5 @@ public:
     void generalPurposeInterpolationGPL(GTEInstruction instruction);
     void perspectiveTransformation(GTEInstruction instruction, unsigned int index);
     void perspectiveTransformationOnThreePoints(GTEInstruction instruction);
+    void normalColor(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -147,5 +147,6 @@ public:
     void perspectiveTransformationOnThreePoints(GTEInstruction instruction);
     void normalColorNCS(GTEInstruction instruction, unsigned int index);
     void normalColorNCT(GTEInstruction instruction);
-    void normalColorColorSingleVector(GTEInstruction instruction);
+    void normalColorColorSingleVector(GTEInstruction instruction, unsigned int index);
+    void normalColorColorTripleVector(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -143,4 +143,5 @@ public:
     void outerProductOfTwoVectors(GTEInstruction instruction);
     void generalPurposeInterpolationGPF(GTEInstruction instruction);
     void generalPurposeInterpolationGPL(GTEInstruction instruction);
+    void perspectiveTransformation(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -147,4 +147,5 @@ public:
     void perspectiveTransformationOnThreePoints(GTEInstruction instruction);
     void normalColorNCS(GTEInstruction instruction, unsigned int index);
     void normalColorNCT(GTEInstruction instruction);
+    void normalColorColorSingleVector(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -140,4 +140,5 @@ public:
     void normalClipping(GTEInstruction instruction);
     void averageOfThreeZValues(GTEInstruction instruction);
     void averageOfFourZValues(GTEInstruction instruction);
+    void outerProductOfTwoVectors(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -190,7 +190,9 @@ public:
     void execute(uint32_t value);
 
     int64_t calculateMAC(unsigned int index, int64_t value);
+    int32_t calculateMAC0(int64_t value);
     int16_t calculateIR(unsigned int index, int64_t value, bool lm);
 
     void squareVector(GTEInstruction instruction);
+    void normalClipping(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -143,5 +143,6 @@ public:
     void outerProductOfTwoVectors(GTEInstruction instruction);
     void generalPurposeInterpolationGPF(GTEInstruction instruction);
     void generalPurposeInterpolationGPL(GTEInstruction instruction);
-    void perspectiveTransformation(GTEInstruction instruction);
+    void perspectiveTransformation(GTEInstruction instruction, unsigned int index);
+    void perspectiveTransformationOnThreePoints(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -141,4 +141,5 @@ public:
     void averageOfThreeZValues(GTEInstruction instruction);
     void averageOfFourZValues(GTEInstruction instruction);
     void outerProductOfTwoVectors(GTEInstruction instruction);
+    void generalPurposeInterpolationGPF(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -154,4 +154,5 @@ public:
     void depthCueingDPCT(GTEInstruction instruction);
     void interpolationOfVectorAndFarColorVector(GTEInstruction instruction);
     void colorDepthQue(GTEInstruction instruction);
+    void normalColorDepthCueSingleVector(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -150,5 +150,6 @@ public:
     void normalColorColorSingleVector(GTEInstruction instruction, unsigned int index);
     void normalColorColorTripleVector(GTEInstruction instruction);
     void colorColor(GTEInstruction instruction);
-    void depthCueing(GTEInstruction instruction);
+    void depthCueingDPCS(GTEInstruction instruction, bool useFIFO);
+    void depthCueingDPCT(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include "Logger.hpp"
+#include "GTEInstruction.hpp"
 
 struct GTEVector3_16_t {
     int16_t x;
@@ -187,4 +188,9 @@ public:
     void setControl(uint32_t index, uint32_t value);
     uint32_t getControl(uint32_t index);
     void execute(uint32_t value);
+
+    int64_t calculateMAC(unsigned int index, int64_t value);
+    int16_t calculateIR(unsigned int index, int64_t value, bool lm);
+
+    void squareVector(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -149,4 +149,5 @@ public:
     void normalColorNCT(GTEInstruction instruction);
     void normalColorColorSingleVector(GTEInstruction instruction, unsigned int index);
     void normalColorColorTripleVector(GTEInstruction instruction);
+    void colorColor(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -153,4 +153,5 @@ public:
     void depthCueingDPCS(GTEInstruction instruction, bool useFIFO);
     void depthCueingDPCT(GTEInstruction instruction);
     void interpolationOfVectorAndFarColorVector(GTEInstruction instruction);
+    void colorDepthQue(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -139,4 +139,5 @@ public:
     void squareVector(GTEInstruction instruction);
     void normalClipping(GTEInstruction instruction);
     void averageOfThreeZValues(GTEInstruction instruction);
+    void averageOfFourZValues(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -192,7 +192,9 @@ public:
     int64_t calculateMAC(unsigned int index, int64_t value);
     int32_t calculateMAC0(int64_t value);
     int16_t calculateIR(unsigned int index, int64_t value, bool lm);
+    uint16_t calculateSZ3(int64_t value);
 
     void squareVector(GTEInstruction instruction);
     void normalClipping(GTEInstruction instruction);
+    void averageOfThreeZValues(GTEInstruction instruction);
 };

--- a/include/GTE.hpp
+++ b/include/GTE.hpp
@@ -154,5 +154,6 @@ public:
     void depthCueingDPCT(GTEInstruction instruction);
     void interpolationOfVectorAndFarColorVector(GTEInstruction instruction);
     void colorDepthQue(GTEInstruction instruction);
-    void normalColorDepthCueSingleVector(GTEInstruction instruction);
+    void normalColorDepthCueSingleVector(GTEInstruction instruction, unsigned int index);
+    void normalColorDepthCueTripleVector(GTEInstruction instruction);
 };

--- a/include/GTEFlagRegister.hpp
+++ b/include/GTEFlagRegister.hpp
@@ -58,9 +58,12 @@ union GTEFlagRegister {
     void setMACPositive(unsigned int index);
     void setIR(unsigned int index);
     void setRGB(unsigned int index);
+    void setSXY2(unsigned int index);
     int64_t calculateMAC(unsigned int index, int64_t value);
     int32_t calculateMAC0(int64_t value);
     int16_t calculateIR(unsigned int index, int64_t value, bool lm);
+    int16_t calculateIR0(int64_t value);
     uint16_t calculateSZ3(int64_t value);
     uint8_t calculateRGB(unsigned int index, int value);
+    int16_t calculateSXY2(unsigned int index, int value);
 };

--- a/include/GTEFlagRegister.hpp
+++ b/include/GTEFlagRegister.hpp
@@ -57,8 +57,10 @@ union GTEFlagRegister {
     void setMACNegative(unsigned int index);
     void setMACPositive(unsigned int index);
     void setIR(unsigned int index);
+    void setRGB(unsigned int index);
     int64_t calculateMAC(unsigned int index, int64_t value);
     int32_t calculateMAC0(int64_t value);
     int16_t calculateIR(unsigned int index, int64_t value, bool lm);
     uint16_t calculateSZ3(int64_t value);
+    uint8_t calculateRGB(unsigned int index, int value);
 };

--- a/include/GTEFlagRegister.hpp
+++ b/include/GTEFlagRegister.hpp
@@ -1,0 +1,64 @@
+#pragma once
+#include <cstdint>
+
+/*
+cop2r63 (cnt31) - FLAG - Returns any calculation errors.
+0-11 Not used (always zero) (Read only)
+12   IR0 saturated to +0000h..+1000h
+13   SY2 saturated to -0400h..+03FFh
+14   SX2 saturated to -0400h..+03FFh
+15   MAC0 Result larger than 31 bits and negative
+16   MAC0 Result larger than 31 bits and positive
+17   Divide overflow. RTPS/RTPT division result saturated to max=1FFFFh
+18   SZ3 or OTZ saturated to +0000h..+FFFFh
+19   Color-FIFO-B saturated to +00h..+FFh
+20   Color-FIFO-G saturated to +00h..+FFh
+21   Color-FIFO-R saturated to +00h..+FFh
+22   IR3 saturated to +0000h..+7FFFh (lm=1) or to -8000h..+7FFFh (lm=0)
+23   IR2 saturated to +0000h..+7FFFh (lm=1) or to -8000h..+7FFFh (lm=0)
+24   IR1 saturated to +0000h..+7FFFh (lm=1) or to -8000h..+7FFFh (lm=0)
+25   MAC3 Result larger than 43 bits and negative
+26   MAC2 Result larger than 43 bits and negative
+27   MAC1 Result larger than 43 bits and negative
+28   MAC3 Result larger than 43 bits and positive
+29   MAC2 Result larger than 43 bits and positive
+30   MAC1 Result larger than 43 bits and positive
+31   Error Flag (Bit30..23, and 18..13 ORed together) (Read only)
+*/
+union GTEFlagRegister {
+    struct {
+        uint32_t unused : 12;
+        uint32_t ir0 : 1;
+        uint32_t sy2 : 1;
+        uint32_t sx2 : 1;
+        uint32_t mac0Negative : 1;
+        uint32_t mac0Positive : 1;
+        uint32_t divideOverflow : 1;
+        uint32_t sz3OrOtz : 1;
+        uint32_t colorFifoB : 1;
+        uint32_t colorFifoG : 1;
+        uint32_t colorFifoR : 1;
+        uint32_t ir3 : 1;
+        uint32_t ir2 : 1;
+        uint32_t ir1 : 1;
+        uint32_t mac3Negative : 1;
+        uint32_t mac2Negative : 1;
+        uint32_t mac1Negative : 1;
+        uint32_t mac3Positive : 1;
+        uint32_t mac2Positive : 1;
+        uint32_t mac1Positive : 1;
+        uint32_t error : 1;
+    };
+
+    uint32_t _value;
+
+    GTEFlagRegister() : _value(0) {};
+
+    void setMACNegative(unsigned int index);
+    void setMACPositive(unsigned int index);
+    void setIR(unsigned int index);
+    int64_t calculateMAC(unsigned int index, int64_t value);
+    int32_t calculateMAC0(int64_t value);
+    int16_t calculateIR(unsigned int index, int64_t value, bool lm);
+    uint16_t calculateSZ3(int64_t value);
+};

--- a/src/GTE.cpp
+++ b/src/GTE.cpp
@@ -653,6 +653,10 @@ void GTE::execute(uint32_t value) {
             interpolationOfVectorAndFarColorVector(instruction);
             break;
         }
+        case 0x13: {
+            normalColorDepthCueSingleVector(instruction);
+            break;
+        }
         case 0x14: {
             colorDepthQue(instruction);
             break;
@@ -1571,6 +1575,107 @@ Calculation:
 [0,8,0]   B0<-B1<-B2<- Lm_C3[MAC3]                             [1,27,4]
 */
 void GTE::colorDepthQue(GTEInstruction instruction) {
+    int64_t temporalMAC = 0;
+
+    temporalMAC = flag.calculateMAC(1, (int64_t)bk.r * 0x1000 + lr.v0.x * ir1);
+    temporalMAC = flag.calculateMAC(1, temporalMAC + (int64_t)lr.v0.y * ir2);
+    temporalMAC = flag.calculateMAC(1, temporalMAC + (int64_t)lr.v0.z * ir3);
+    mac1 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    temporalMAC = flag.calculateMAC(2, (int64_t)bk.g * 0x1000 + lr.v1.x * ir1);
+    temporalMAC = flag.calculateMAC(2, temporalMAC + (int64_t)lr.v1.y * ir2);
+    temporalMAC = flag.calculateMAC(2, temporalMAC + (int64_t)lr.v1.z * ir3);
+    mac2 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    temporalMAC = flag.calculateMAC(3, (int64_t)bk.b * 0x1000 + lr.v2.x * ir1);
+    temporalMAC = flag.calculateMAC(3, temporalMAC + (int64_t)lr.v2.y * ir2);
+    temporalMAC = flag.calculateMAC(3, temporalMAC + (int64_t)lr.v2.z * ir3);
+    mac3 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
+    mac1 = flag.calculateMAC(1, (rgbc.r * ir1) << 4);
+    mac2 = flag.calculateMAC(2, (rgbc.g * ir2) << 4);
+    mac3 = flag.calculateMAC(3, (rgbc.b * ir3) << 4);
+
+    int32_t mac1Input = mac1;
+    int32_t mac2Input = mac2;
+    int32_t mac3Input = mac3;
+
+    mac1 = flag.calculateMAC(1, ((int64_t)fc.r << 12) - mac1Input) >> instruction.shiftFraction * 12;
+    mac2 = flag.calculateMAC(2, ((int64_t)fc.g << 12) - mac2Input) >> instruction.shiftFraction * 12;
+    mac3 = flag.calculateMAC(3, ((int64_t)fc.b << 12) - mac3Input) >> instruction.shiftFraction * 12;
+
+    ir1 = flag.calculateIR(1, mac1, false);
+    ir2 = flag.calculateIR(2, mac2, false);
+    ir3 = flag.calculateIR(3, mac3, false);
+
+    mac1 = flag.calculateMAC(1, ((int64_t)ir1 * ir0) + mac1Input) >> instruction.shiftFraction * 12;
+    mac2 = flag.calculateMAC(2, ((int64_t)ir2 * ir0) + mac2Input) >> instruction.shiftFraction * 12;
+    mac3 = flag.calculateMAC(3, ((int64_t)ir3 * ir0) + mac3Input) >> instruction.shiftFraction * 12;
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
+    rgb0._value = rgb1._value;
+    rgb1._value = rgb2._value;
+
+    rgb2.r = flag.calculateRGB(1, mac1 >> 4);
+    rgb2.g = flag.calculateRGB(2, mac2 >> 4);
+    rgb2.b = flag.calculateRGB(3, mac3 >> 4);
+    rgb2.c = rgbc.c;
+}
+
+/*
+NCDS     19       Normal color depth cue single vector
+Fields:  none
+Opcode:  cop2 $0e80413
+In:      V0                Normal vector                       [1,3,12]
+         BK                Background color       RBK,GBK,BBK  [1,19,12]
+         RGB               Primary color          R,G,B,CODE   [0,8,0]
+         LLM               Light matrix                        [1,3,12]
+         LCM               Color matrix                        [1,3,12]
+         IR0               Interpolation value                 [1,3,12]
+Out:     RGBn              RGB fifo.              Rn,Gn,Bn,CDn [0,8,0]
+         [IR1,IR2,IR3]     Color vector                        [1,11,4]
+         [MAC1,MAC2,MAC3]  Color vector                        [1,27,4]
+
+Calculation:
+[1,19,12] MAC1=A1[L11*VX0 + L12*VY0 + L13*VZ0]                 [1,19,24]
+[1,19,12] MAC2=A1[L21*VX0 + L22*VY0 + L23*VZ0]                 [1,19,24]
+[1,19,12] MAC3=A1[L31*VX0 + L32*VY0 + L33*VZ0]                 [1,19,24]
+[1,3,12]  IR1= Lm_B1[MAC1]                                     [1,19,12][lm=1]
+[1,3,12]  IR2= Lm_B2[MAC2]                                     [1,19,12][lm=1]
+[1,3,12]  IR3= Lm_B3[MAC3]                                     [1,19,12][lm=1]
+[1,19,12] MAC1=A1[RBK + LR1*IR1 + LR2*IR2 + LR3*IR3]           [1,19,24]
+[1,19,12] MAC2=A1[GBK + LG1*IR1 + LG2*IR2 + LG3*IR3]           [1,19,24]
+[1,19,12] MAC3=A1[BBK + LB1*IR1 + LB2*IR2 + LB3*IR3]           [1,19,24]
+[1,3,12]  IR1= Lm_B1[MAC1]                                     [1,19,12][lm=1]
+[1,3,12]  IR2= Lm_B2[MAC2]                                     [1,19,12][lm=1]
+[1,3,12]  IR3= Lm_B3[MAC3]                                     [1,19,12][lm=1]
+[1,27,4]  MAC1=A1[R*IR1 + IR0*(Lm_B1[RFC-R*IR1])]              [1,27,16][lm=0]
+[1,27,4]  MAC2=A1[G*IR2 + IR0*(Lm_B2[GFC-G*IR2])]              [1,27,16][lm=0]
+[1,27,4]  MAC3=A1[B*IR3 + IR0*(Lm_B3[BFC-B*IR3])]              [1,27,16][lm=0]
+[1,3,12]  IR1= Lm_B1[MAC1]                                     [1,27,4][lm=1]
+[1,3,12]  IR2= Lm_B2[MAC2]                                     [1,27,4][lm=1]
+[1,3,12]  IR3= Lm_B3[MAC3]                                     [1,27,4][lm=1]
+[0,8,0]   Cd0<-Cd1<-Cd2<- CODE
+[0,8,0]   R0<-R1<-R2<- Lm_C1[MAC1]                             [1,27,4]
+[0,8,0]   G0<-G1<-G2<- Lm_C2[MAC2]                             [1,27,4]
+[0,8,0]   B0<-B1<-B2<- Lm_C3[MAC3]                             [1,27,4]
+*/
+void GTE::normalColorDepthCueSingleVector(GTEInstruction instruction) {
+    mac1 = flag.calculateMAC(1, (int64_t)l.v0.x * v0.x + l.v0.y * v0.y + l.v0.z * v0.z) >> (instruction.shiftFraction * 12);
+    mac2 = flag.calculateMAC(2, (int64_t)l.v1.x * v0.x + l.v1.y * v0.y + l.v1.z * v0.z) >> (instruction.shiftFraction * 12);
+    mac3 = flag.calculateMAC(3, (int64_t)l.v2.x * v0.x + l.v2.y * v0.y + l.v2.z * v0.z) >> (instruction.shiftFraction * 12);
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
     int64_t temporalMAC = 0;
 
     temporalMAC = flag.calculateMAC(1, (int64_t)bk.r * 0x1000 + lr.v0.x * ir1);

--- a/src/GTE.cpp
+++ b/src/GTE.cpp
@@ -649,6 +649,10 @@ void GTE::execute(uint32_t value) {
             normalColorColorSingleVector(instruction, 0);
             break;
         }
+        case 0x1c: {
+            colorColor(instruction);
+            break;
+        }
         case 0x1e: {
             normalColorNCS(instruction, 0);
             break;
@@ -1283,4 +1287,77 @@ void GTE::normalColorColorTripleVector(GTEInstruction instruction) {
     normalColorColorSingleVector(instruction, 0);
     normalColorColorSingleVector(instruction, 1);
     normalColorColorSingleVector(instruction, 2);
+}
+
+/*
+CC       11       Color Color.
+Fields:  none
+Opcode:  cop2 $138041C
+In:      [IR1,IR2,IR3]     Vector                              [1,3,12]
+         BK                Background color       RBK,GBK,BBK  [1,19,12]
+         RGB               Primary color          R,G,B,CODE   [0,8,0]
+         LCM               Color matrix                        [1,3,12]
+Out:     RGBn              RGB fifo.              Rn,Gn,Bn,CDn [0,8,0]
+         [IR1,IR2,IR3]     Color vector                        [1,11,4]
+         [MAC1,MAC2,MAC3]  Color vector                        [1,27,4]
+
+Calculations:
+[1,19,12] MAC1=A1[RBK + LR1*IR1 + LR2*IR2 + LR3*IR3]           [1,19,24]
+[1,19,12] MAC2=A2[GBK + LG1*IR1 + LG2*IR2 + LG3*IR3]           [1,19,24]
+[1,19,12] MAC3=A3[BBK + LB1*IR1 + LB2*IR2 + LB3*IR3]           [1,19,24]
+[1,3,12]  IR1= Lm_B1[MAC1]                                     [1,19,12][lm=1]
+[1,3,12]  IR2= Lm_B2[MAC2]                                     [1,19,12][lm=1]
+[1,3,12]  IR3= Lm_B3[MAC3]                                     [1,19,12][lm=1]
+[1,27,4]  MAC1=A1[R*IR1]                                       [1,27,16]
+[1,27,4]  MAC2=A2[G*IR2]                                       [1,27,16]
+[1,27,4]  MAC3=A3[B*IR3]                                       [1,27,16]
+[1,3,12]  IR1= Lm_B1[MAC1]                                     [1,27,4][lm=1]
+[1,3,12]  IR2= Lm_B2[MAC2]                                     [1,27,4][lm=1]
+[1,3,12]  IR3= Lm_B3[MAC3]                                     [1,27,4][lm=1]
+[0,8,0]   Cd0<-Cd1<-Cd2<- CODE
+[0,8,0]   R0<-R1<-R2<- Lm_C1[MAC1]                             [1,27,4]
+[0,8,0]   G0<-G1<-G2<- Lm_C2[MAC2]                             [1,27,4]
+[0,8,0]   B0<-B1<-B2<- Lm_C3[MAC3]                             [1,27,4]
+*/
+void GTE::colorColor(GTEInstruction instruction) {
+    int64_t temporalMAC = 0;
+
+    temporalMAC = flag.calculateMAC(1, (int64_t)bk.r * 0x1000 + lr.v0.x * ir1);
+    temporalMAC = flag.calculateMAC(1, temporalMAC + (int64_t)lr.v0.y * ir2);
+    temporalMAC = flag.calculateMAC(1, temporalMAC + (int64_t)lr.v0.z * ir3);
+    mac1 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    temporalMAC = flag.calculateMAC(2, (int64_t)bk.g * 0x1000 + lr.v1.x * ir1);
+    temporalMAC = flag.calculateMAC(2, temporalMAC + (int64_t)lr.v1.y * ir2);
+    temporalMAC = flag.calculateMAC(2, temporalMAC + (int64_t)lr.v1.z * ir3);
+    mac2 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    temporalMAC = flag.calculateMAC(3, (int64_t)bk.b * 0x1000 + lr.v2.x * ir1);
+    temporalMAC = flag.calculateMAC(3, temporalMAC + (int64_t)lr.v2.y * ir2);
+    temporalMAC = flag.calculateMAC(3, temporalMAC + (int64_t)lr.v2.z * ir3);
+    mac3 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
+    mac1 = flag.calculateMAC(1, (rgbc.r * ir1) << 4);
+    mac2 = flag.calculateMAC(2, (rgbc.g * ir2) << 4);
+    mac3 = flag.calculateMAC(3, (rgbc.b * ir3) << 4);
+
+    mac1 = flag.calculateMAC(1, mac1 >> (instruction.shiftFraction * 12));
+    mac2 = flag.calculateMAC(2, mac2 >> (instruction.shiftFraction * 12));
+    mac3 = flag.calculateMAC(3, mac3 >> (instruction.shiftFraction * 12));
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
+    rgb0._value = rgb1._value;
+    rgb1._value = rgb2._value;
+
+    rgb2.r = flag.calculateRGB(1, mac1 >> 4);
+    rgb2.g = flag.calculateRGB(2, mac2 >> 4);
+    rgb2.b = flag.calculateRGB(3, mac3 >> 4);
+    rgb2.c = rgbc.c;
 }

--- a/src/GTE.cpp
+++ b/src/GTE.cpp
@@ -645,6 +645,10 @@ void GTE::execute(uint32_t value) {
             outerProductOfTwoVectors(instruction);
             break;
         }
+        case 0x1b: {
+            normalColorColorSingleVector(instruction);
+            break;
+        }
         case 0x1e: {
             normalColorNCS(instruction, 0);
             break;
@@ -1141,4 +1145,94 @@ void GTE::normalColorNCT(GTEInstruction instruction) {
     normalColorNCS(instruction, 0);
     normalColorNCS(instruction, 1);
     normalColorNCS(instruction, 2);
+}
+
+/*
+NCCS     17       Normal Color Color single vector
+Fields:  none
+Opcode:  cop2 $108041B
+
+In:      V0                Normal vector                       [1,3,12]
+         BK                Background color       RBK,GBK,BBK  [1,19,12]
+         RGB               Primary color          R,G,B,CODE   [0,8,0]
+         LLM               Light matrix                        [1,3,12]
+         LCM               Color matrix                        [1,3,12]
+Out:     RGBn              RGB fifo.              Rn,Gn,Bn,CDn [0,8,0]
+         [IR1,IR2,IR3]     Color vector                        [1,11,4]
+         [MAC1,MAC2,MAC3]  Color vector                        [1,27,4]
+
+Calculation:
+
+[1,19,12] MAC1=A1[L11*VX0 + L12*VY0 + L13*VZ0]                  [1,19,24]
+[1,19,12] MAC2=A2[L21*VX0 + L22*VY0 + L23*VZ0]                  [1,19,24]
+[1,19,12] MAC3=A3[L31*VX0 + L32*VY0 + L33*VZ0]                  [1,19,24]
+[1,3,12]  IR1= Lm_B1[MAC1]                                      [1,19,12][lm=1]
+[1,3,12]  IR2= Lm_B2[MAC2]                                      [1,19,12][lm=1]
+[1,3,12]  IR3= Lm_B3[MAC3]                                      [1,19,12][lm=1]
+[1,19,12] MAC1=A1[RBK + LR1*IR1 + LR2*IR2 + LR3*IR3]            [1,19,24]
+[1,19,12] MAC2=A2[GBK + LG1*IR1 + LG2*IR2 + LG3*IR3]            [1,19,24]
+[1,19,12] MAC3=A3[BBK + LB1*IR1 + LB2*IR2 + LB3*IR3]            [1,19,24]
+[1,3,12]  IR1= Lm_B1[MAC1]                                      [1,19,12][lm=1]
+[1,3,12]  IR2= Lm_B2[MAC2]                                      [1,19,12][lm=1]
+[1,3,12]  IR3= Lm_B3[MAC3]                                      [1,19,12][lm=1]
+[1,27,4]  MAC1=A1[R*IR1]                                        [1,27,16]
+[1,27,4]  MAC2=A2[G*IR2]                                        [1,27,16]
+[1,27,4]  MAC3=A3[B*IR3]                                        [1,27,16]
+[1,3,12]  IR1= Lm_B1[MAC1]                                      [1,27,4][lm=1]
+[1,3,12]  IR2= Lm_B2[MAC2]                                      [1,27,4][lm=1]
+[1,3,12]  IR3= Lm_B3[MAC3]                                      [1,27,4][lm=1]
+[0,8,0]   Cd0<-Cd1<-Cd2<- CODE
+[0,8,0]   R0<-R1<-R2<- Lm_C1[MAC1]                              [1,27,4]
+[0,8,0]   G0<-G1<-G2<- Lm_C2[MAC2]                              [1,27,4]
+[0,8,0]   B0<-B1<-B2<- Lm_C3[MAC3]                              [1,27,4]
+*/
+void GTE::normalColorColorSingleVector(GTEInstruction instruction) {
+    mac1 = flag.calculateMAC(1, (int64_t)l.v0.x * v0.x + l.v0.y * v0.y + l.v0.z * v0.z) >> (instruction.shiftFraction * 12);
+    mac2 = flag.calculateMAC(2, (int64_t)l.v1.x * v0.x + l.v1.y * v0.y + l.v1.z * v0.z) >> (instruction.shiftFraction * 12);
+    mac3 = flag.calculateMAC(3, (int64_t)l.v2.x * v0.x + l.v2.y * v0.y + l.v2.z * v0.z) >> (instruction.shiftFraction * 12);
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
+    int64_t temporalMAC = 0;
+
+    temporalMAC = flag.calculateMAC(1, (int64_t)bk.r * 0x1000 + lr.v0.x * ir1);
+    temporalMAC = flag.calculateMAC(1, temporalMAC + (int64_t)lr.v0.y * ir2);
+    temporalMAC = flag.calculateMAC(1, temporalMAC + (int64_t)lr.v0.z * ir3);
+    mac1 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    temporalMAC = flag.calculateMAC(2, (int64_t)bk.g * 0x1000 + lr.v1.x * ir1);
+    temporalMAC = flag.calculateMAC(2, temporalMAC + (int64_t)lr.v1.y * ir2);
+    temporalMAC = flag.calculateMAC(2, temporalMAC + (int64_t)lr.v1.z * ir3);
+    mac2 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    temporalMAC = flag.calculateMAC(3, (int64_t)bk.b * 0x1000 + lr.v2.x * ir1);
+    temporalMAC = flag.calculateMAC(3, temporalMAC + (int64_t)lr.v2.y * ir2);
+    temporalMAC = flag.calculateMAC(3, temporalMAC + (int64_t)lr.v2.z * ir3);
+    mac3 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
+    mac1 = flag.calculateMAC(1, (rgbc.r * ir1) << 4);
+    mac2 = flag.calculateMAC(2, (rgbc.g * ir2) << 4);
+    mac3 = flag.calculateMAC(3, (rgbc.b * ir3) << 4);
+
+    mac1 = flag.calculateMAC(1, mac1 >> (instruction.shiftFraction * 12));
+    mac2 = flag.calculateMAC(2, mac2 >> (instruction.shiftFraction * 12));
+    mac3 = flag.calculateMAC(3, mac3 >> (instruction.shiftFraction * 12));
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
+    rgb0._value = rgb1._value;
+    rgb1._value = rgb2._value;
+
+    rgb2.r = flag.calculateRGB(1, mac1 >> 4);
+    rgb2.g = flag.calculateRGB(2, mac2 >> 4);
+    rgb2.b = flag.calculateRGB(3, mac3 >> 4);
+    rgb2.c = rgbc.c;
 }

--- a/src/GTE.cpp
+++ b/src/GTE.cpp
@@ -645,6 +645,10 @@ void GTE::execute(uint32_t value) {
             outerProductOfTwoVectors(instruction);
             break;
         }
+        case 0x1e: {
+            normalColor(instruction);
+            break;
+        }
         case 0x28: {
             squareVector(instruction);
             break;
@@ -1022,4 +1026,74 @@ void GTE::perspectiveTransformationOnThreePoints(GTEInstruction instruction) {
     perspectiveTransformation(instruction, 0);
     perspectiveTransformation(instruction, 1);
     perspectiveTransformation(instruction, 2);
+}
+
+/*
+NCS      14       Normal color
+Fields:  none
+Opcode:  cop2 $0C8041E
+
+In:      V0                Normal vector                       [1,3,12]
+         BK                Background color       RBK,GBK,BBK  [1,19,12]
+         CODE              Code value from RGB.           CODE [0,8,0]
+         LCM               Color matrix                        [1,3,12]
+         LLM               Light matrix                        [1,3,12]
+Out:     RGBn              RGB fifo.              Rn,Gn,Bn,CDn [0,8,0]
+         [IR1,IR2,IR3]     Color vector                        [1,11,4]
+         [MAC1,MAC2,MAC3]  Color vector                        [1,27,4]
+
+[1,19,12] MAC1=A1[L11*VX0 + L12*VY0 + L13*VZ0]                 [1,19,24]
+[1,19,12] MAC2=A2[L21*VX0 + L22*VY0 + L23*VZ0]                 [1,19,24]
+[1,19,12] MAC3=A3[L31*VX0 + L32*VY0 + L33*VZ0]                 [1,19,24]
+[1,3,12]  IR1= Lm_B1[MAC1]                                     [1,19,12][lm=1]
+[1,3,12]  IR2= Lm_B2[MAC2]                                     [1,19,12][lm=1]
+[1,3,12]  IR3= Lm_B3[MAC3]                                     [1,19,12][lm=1]
+[1,19,12] MAC1=A1[RBK + LR1*IR1 + LR2*IR2 + LR3*IR3]           [1,19,24]
+[1,19,12] MAC2=A2[GBK + LG1*IR1 + LG2*IR2 + LG3*IR3]           [1,19,24]
+[1,19,12] MAC3=A3[BBK + LB1*IR1 + LB2*IR2 + LB3*IR3]           [1,19,24]
+[1,3,12]  IR1= Lm_B1[MAC1]                                     [1,19,12][lm=1]
+[1,3,12]  IR2= Lm_B2[MAC2]                                     [1,19,12][lm=1]
+[1,3,12]  IR3= Lm_B3[MAC3]                                     [1,19,12][lm=1]
+[0,8,0]   Cd0<-Cd1<-Cd2<- CODE
+[0,8,0]   R0<-R1<-R2<- Lm_C1[MAC1]                             [1,27,4]
+[0,8,0]   G0<-G1<-G2<- Lm_C2[MAC2]                             [1,27,4]
+[0,8,0]   B0<-B1<-B2<- Lm_C3[MAC3]                             [1,27,4]
+*/
+void GTE::normalColor(GTEInstruction instruction) {
+    mac1 = flag.calculateMAC(1, (int64_t)l.v0.x * v0.x + l.v0.y * v0.y + l.v0.z * v0.z) >> (instruction.shiftFraction * 12);
+    mac2 = flag.calculateMAC(2, (int64_t)l.v1.x * v0.x + l.v1.y * v0.y + l.v1.z * v0.z) >> (instruction.shiftFraction * 12);
+    mac3 = flag.calculateMAC(3, (int64_t)l.v2.x * v0.x + l.v2.y * v0.y + l.v2.z * v0.z) >> (instruction.shiftFraction * 12);
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
+    int64_t temporalMAC = 0;
+
+    temporalMAC = flag.calculateMAC(1, (int64_t)bk.r * 0x1000 + lr.v0.x * ir1);
+    temporalMAC = flag.calculateMAC(1, temporalMAC + (int64_t)lr.v0.y * ir2);
+    temporalMAC = flag.calculateMAC(1, temporalMAC + (int64_t)lr.v0.z * ir3);
+    mac1 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    temporalMAC = flag.calculateMAC(2, (int64_t)bk.g * 0x1000 + lr.v1.x * ir1);
+    temporalMAC = flag.calculateMAC(2, temporalMAC + (int64_t)lr.v1.y * ir2);
+    temporalMAC = flag.calculateMAC(2, temporalMAC + (int64_t)lr.v1.z * ir3);
+    mac2 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    temporalMAC = flag.calculateMAC(3, (int64_t)bk.b * 0x1000 + lr.v2.x * ir1);
+    temporalMAC = flag.calculateMAC(3, temporalMAC + (int64_t)lr.v2.y * ir2);
+    temporalMAC = flag.calculateMAC(3, temporalMAC + (int64_t)lr.v2.z * ir3);
+    mac3 = temporalMAC >> (instruction.shiftFraction * 12);
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
+    rgb0._value = rgb1._value;
+    rgb1._value = rgb2._value;
+
+    rgb2.r = flag.calculateRGB(1, mac1 >> 4);
+    rgb2.g = flag.calculateRGB(2, mac2 >> 4);
+    rgb2.b = flag.calculateRGB(3, mac3 >> 4);
+    rgb2.c = rgbc.c;
 }

--- a/src/GTE.cpp
+++ b/src/GTE.cpp
@@ -43,7 +43,8 @@ GTE::GTE(LogLevel logLevel) : logger(logLevel, "  GTE: "),
     dqa(0),
     dqb(0),
     zsf3(0),
-    zsf4(0)
+    zsf4(0),
+    flag(GTEFLAGRegister())
 {
 }
 

--- a/src/GTE.cpp
+++ b/src/GTE.cpp
@@ -685,6 +685,10 @@ void GTE::execute(uint32_t value) {
             squareVector(instruction);
             break;
         }
+        case 0x29: {
+            depthCueColorLight(instruction);
+            break;
+        }
         case 0x2a: {
             depthCueingDPCT(instruction);
             break;
@@ -1774,10 +1778,67 @@ Out:     RGBn              RGB fifo.              Rn,Gn,Bn,CDn [0,8,0]
 Calculation:
 Same as NCDS but repeats for v1 and v2.
 */
-
 void GTE::normalColorDepthCueTripleVector(GTEInstruction instruction) {
     normalColorDepthCueSingleVector(instruction, 0);
     normalColorDepthCueSingleVector(instruction, 1);
     normalColorDepthCueSingleVector(instruction, 2);
 }
 
+/*
+DCPL     8        Depth Cue Color light
+Fields:  none
+Opcode:  cop2 $0680029
+In:      RGB               Primary color.         R,G,B,CODE   [0,8,0]
+         IR0               interpolation value.                [1,3,12]
+         [IR1,IR2,IR3]     Local color vector.                 [1,3,12]
+         CODE              Code value from RGB.           CODE [0,8,0]
+         FC                Far color.                          [1,27,4]
+Out:     RGBn              RGB fifo               Rn,Gn,Bn,CDn [0,8,0]
+         [IR1,IR2,IR3]     Color vector                        [1,11,4]
+         [MAC1,MAC2,MAC3]  Color vector                        [1,27,4]
+
+Calculation:
+[1,27,4]  MAC1=A1[R*IR1 + IR0*(Lm_B1[RFC - R * IR1])]          [1,27,16]
+[1,27,4]  MAC2=A2[G*IR2 + IR0*(Lm_B1[GFC - G * IR2])]          [1,27,16]
+[1,27,4]  MAC3=A3[B*IR3 + IR0*(Lm_B1[BFC - B * IR3])]          [1,27,16]
+[1,11,4]  IR1=Lm_B1[MAC1]                                      [1,27,4]
+[1,11,4]  IR2=Lm_B2[MAC2]                                      [1,27,4]
+[1,11,4]  IR3=Lm_B3[MAC3]                                      [1,27,4]
+[0,8,0]   Cd0<-Cd1<-Cd2<- CODE
+[0,8,0]   R0<-R1<-R2<- Lm_C1[MAC1]                             [1,27,4]
+[0,8,0]   G0<-G1<-G2<- Lm_C2[MAC2]                             [1,27,4]
+[0,8,0]   B0<-B1<-B2<- Lm_C3[MAC3]                             [1,27,4]
+*/
+void GTE::depthCueColorLight(GTEInstruction instruction) {
+    mac1 = flag.calculateMAC(1, rgbc.r * ir1) << 4;
+    mac2 = flag.calculateMAC(2, rgbc.g * ir2) << 4;
+    mac3 = flag.calculateMAC(3, rgbc.b * ir3) << 4;
+
+    int32_t mac1Input = mac1;
+    int32_t mac2Input = mac2;
+    int32_t mac3Input = mac3;
+
+    mac1 = flag.calculateMAC(1, ((int64_t)fc.r << 12) - mac1Input) >> instruction.shiftFraction * 12;
+    mac2 = flag.calculateMAC(2, ((int64_t)fc.g << 12) - mac2Input) >> instruction.shiftFraction * 12;
+    mac3 = flag.calculateMAC(3, ((int64_t)fc.b << 12) - mac3Input) >> instruction.shiftFraction * 12;
+
+    ir1 = flag.calculateIR(1, mac1, false);
+    ir2 = flag.calculateIR(2, mac2, false);
+    ir3 = flag.calculateIR(3, mac3, false);
+
+    mac1 = flag.calculateMAC(1, ((int64_t)ir1 * ir0) + mac1Input) >> instruction.shiftFraction * 12;
+    mac2 = flag.calculateMAC(2, ((int64_t)ir2 * ir0) + mac2Input) >> instruction.shiftFraction * 12;
+    mac3 = flag.calculateMAC(3, ((int64_t)ir3 * ir0) + mac3Input) >> instruction.shiftFraction * 12;
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
+    rgb0._value = rgb1._value;
+    rgb1._value = rgb2._value;
+
+    rgb2.r = flag.calculateRGB(1, mac1 >> 4);
+    rgb2.g = flag.calculateRGB(2, mac2 >> 4);
+    rgb2.b = flag.calculateRGB(3, mac3 >> 4);
+    rgb2.c = rgbc.c;
+}

--- a/src/GTE.cpp
+++ b/src/GTE.cpp
@@ -646,7 +646,11 @@ void GTE::execute(uint32_t value) {
             break;
         }
         case 0x1e: {
-            normalColor(instruction);
+            normalColorNCS(instruction, 0);
+            break;
+        }
+        case 0x20: {
+            normalColorNCT(instruction);
             break;
         }
         case 0x28: {
@@ -1059,10 +1063,29 @@ Out:     RGBn              RGB fifo.              Rn,Gn,Bn,CDn [0,8,0]
 [0,8,0]   G0<-G1<-G2<- Lm_C2[MAC2]                             [1,27,4]
 [0,8,0]   B0<-B1<-B2<- Lm_C3[MAC3]                             [1,27,4]
 */
-void GTE::normalColor(GTEInstruction instruction) {
-    mac1 = flag.calculateMAC(1, (int64_t)l.v0.x * v0.x + l.v0.y * v0.y + l.v0.z * v0.z) >> (instruction.shiftFraction * 12);
-    mac2 = flag.calculateMAC(2, (int64_t)l.v1.x * v0.x + l.v1.y * v0.y + l.v1.z * v0.z) >> (instruction.shiftFraction * 12);
-    mac3 = flag.calculateMAC(3, (int64_t)l.v2.x * v0.x + l.v2.y * v0.y + l.v2.z * v0.z) >> (instruction.shiftFraction * 12);
+void GTE::normalColorNCS(GTEInstruction instruction, unsigned int index) {
+    GTEVector3_16_t v = {};
+    switch (index) {
+        case 0: {
+            v = v0;
+            break;
+        }
+        case 1: {
+            v = v1;
+            break;
+        }
+        case 2: {
+            v = v2;
+            break;
+        }
+        default: {
+            logger.logError("Unhandled index in NCS operation with index: %d", index);
+            break;
+        }
+    }
+    mac1 = flag.calculateMAC(1, (int64_t)l.v0.x * v.x + l.v0.y * v.y + l.v0.z * v.z) >> (instruction.shiftFraction * 12);
+    mac2 = flag.calculateMAC(2, (int64_t)l.v1.x * v.x + l.v1.y * v.y + l.v1.z * v.z) >> (instruction.shiftFraction * 12);
+    mac3 = flag.calculateMAC(3, (int64_t)l.v2.x * v.x + l.v2.y * v.y + l.v2.z * v.z) >> (instruction.shiftFraction * 12);
 
     ir1 = flag.calculateIR(1, mac1, instruction.lm);
     ir2 = flag.calculateIR(2, mac2, instruction.lm);
@@ -1096,4 +1119,26 @@ void GTE::normalColor(GTEInstruction instruction) {
     rgb2.g = flag.calculateRGB(2, mac2 >> 4);
     rgb2.b = flag.calculateRGB(3, mac3 >> 4);
     rgb2.c = rgbc.c;
+}
+
+/*
+NCT      30       Normal color
+Fields:  none
+Opcode:  cop2 $0D80420
+
+In:      V0,V1,V2          Normal vector                       [1,3,12]
+         BK                Background color       RBK,GBK,BBK  [1,19,12]
+         CODE              Code value from RGB.           CODE [0,8,0]
+         LCM               Color matrix                        [1,3,12]
+         LLM               Light matrix                        [1,3,12]
+Out:     RGBn              RGB fifo.              Rn,Gn,Bn,CDn [0,8,0]
+         [IR1,IR2,IR3]     Color vector                        [1,11,4]
+         [MAC1,MAC2,MAC3]  Color vector                        [1,27,4]
+
+Calculation: Same as NCS, but repeated for V1 and V2.
+*/
+void GTE::normalColorNCT(GTEInstruction instruction) {
+    normalColorNCS(instruction, 0);
+    normalColorNCS(instruction, 1);
+    normalColorNCS(instruction, 2);
 }

--- a/src/GTE.cpp
+++ b/src/GTE.cpp
@@ -645,6 +645,10 @@ void GTE::execute(uint32_t value) {
             averageOfThreeZValues(instruction);
             break;
         }
+        case 0x2e: {
+            averageOfFourZValues(instruction);
+            break;
+        }
         default: {
             logger.logError("Unhandled Geometry Transformation Engine command: %#x", instruction.command);
             break;
@@ -719,6 +723,28 @@ void GTE::averageOfThreeZValues(GTEInstruction instruction) {
     // TODO: unused
     (void)instruction;
     int64_t average = (int64_t)zsf3 * sz1 + zsf3 * sz2 + zsf3 * sz3;
+    mac0 = flag.calculateMAC0(average);
+    otz = flag.calculateSZ3(average >> 12);
+}
+
+/*
+AVSZ4    6        Average of four Z values
+Fields:
+Opcode:  cop2 $168002E
+
+in:      SZ1,SZ2,SZ3,SZ4   Z-Values                            [0,16,0]
+         ZSF4              Divider                             [1,3,12]
+out:     OTZ               Average.                            [0,16,0]
+         MAC0              Average.                            [1,31,0]
+
+Calculation:
+[1,31,0] MAC0=F[ZSF4*SZ0 + ZSF4*SZ1 + ZSF4*SZ2 + ZSF4*SZ3]     [1,31,12]
+[0,16,0] OTZ=Lm_D[MAC0]                                        [1,31,0]
+*/
+void GTE::averageOfFourZValues(GTEInstruction instruction) {
+    // TODO: unused
+    (void)instruction;
+    int64_t average = (int64_t)zsf4 * sz0 + zsf4 * sz1 + zsf4 * sz2 + zsf4 * sz3;
     mac0 = flag.calculateMAC0(average);
     otz = flag.calculateSZ3(average >> 12);
 }

--- a/src/GTE.cpp
+++ b/src/GTE.cpp
@@ -657,6 +657,10 @@ void GTE::execute(uint32_t value) {
             generalPurposeInterpolationGPF(instruction);
             break;
         }
+        case 0x3e: {
+            generalPurposeInterpolationGPL(instruction);
+            break;
+        }
         default: {
             logger.logError("Unhandled Geometry Transformation Engine command: %#x", instruction.command);
             break;
@@ -819,6 +823,54 @@ void GTE::generalPurposeInterpolationGPF(GTEInstruction instruction) {
     mac1 = flag.calculateMAC(1, (ir0 * ir1)) >> (instruction.shiftFraction * 12);
     mac2 = flag.calculateMAC(2, (ir0 * ir2)) >> (instruction.shiftFraction * 12);
     mac3 = flag.calculateMAC(3, (ir0 * ir3)) >> (instruction.shiftFraction * 12);
+
+    ir1 = flag.calculateIR(1, mac1, instruction.lm);
+    ir2 = flag.calculateIR(2, mac2, instruction.lm);
+    ir3 = flag.calculateIR(3, mac3, instruction.lm);
+
+    rgb0._value = rgb1._value;
+    rgb1._value = rgb2._value;
+
+    rgb2.r = flag.calculateRGB(1, mac1 >> 4);
+    rgb2.g = flag.calculateRGB(2, mac2 >> 4);
+    rgb2.b = flag.calculateRGB(3, mac3 >> 4);
+    rgb2.c = rgbc.c;
+}
+
+/*
+GPL      5        General purpose interpolation
+Fields:  sf
+Opcode:  cop2 $1A0003E
+
+in:      IR0               scaling factor
+         CODE              code field of RGB
+         [IR1,IR2,IR3]     vector
+         [MAC1,MAC2,MAC3]  vector
+out:     [IR1,IR2,IR3]     vector
+         [MAC1,MAC2,MAC3]  vector
+         RGB2              RGB fifo.
+
+Calculation:
+
+         MAC1=A1[MAC1 + IR0 * IR1]
+         MAC2=A2[MAC2 + IR0 * IR2]
+         MAC3=A3[MAC3 + IR0 * IR3]
+         IR1=Lm_B1[MAC1]
+         IR2=Lm_B2[MAC2]
+         IR3=Lm_B3[MAC3]
+[0,8,0]  Cd0<-Cd1<-Cd2<- CODE
+[0,8,0]  R0<-R1<-R2<- Lm_C1[MAC1]
+[0,8,0]  G0<-G1<-G2<- Lm_C2[MAC2]
+[0,8,0]  B0<-B1<-B2<- Lm_C3[MAC3]
+*/
+void GTE::generalPurposeInterpolationGPL(GTEInstruction instruction) {
+    int64_t m1 = (int64_t)mac1 << (instruction.shiftFraction * 12);
+    int64_t m2 = (int64_t)mac2 << (instruction.shiftFraction * 12);
+    int64_t m3 = (int64_t)mac3 << (instruction.shiftFraction * 12);
+
+    mac1 = flag.calculateMAC(1, m1 + (ir0 * ir1)) >> (instruction.shiftFraction * 12);
+    mac2 = flag.calculateMAC(2, m2 + (ir0 * ir2)) >> (instruction.shiftFraction * 12);
+    mac3 = flag.calculateMAC(3, m3 + (ir0 * ir3)) >> (instruction.shiftFraction * 12);
 
     ir1 = flag.calculateIR(1, mac1, instruction.lm);
     ir2 = flag.calculateIR(2, mac2, instruction.lm);

--- a/src/GTE.cpp
+++ b/src/GTE.cpp
@@ -646,7 +646,7 @@ void GTE::execute(uint32_t value) {
             break;
         }
         case 0x1b: {
-            normalColorColorSingleVector(instruction);
+            normalColorColorSingleVector(instruction, 0);
             break;
         }
         case 0x1e: {
@@ -679,6 +679,10 @@ void GTE::execute(uint32_t value) {
         }
         case 0x3e: {
             generalPurposeInterpolationGPL(instruction);
+            break;
+        }
+        case 0x3f: {
+            normalColorColorTripleVector(instruction);
             break;
         }
         default: {
@@ -1186,10 +1190,29 @@ Calculation:
 [0,8,0]   G0<-G1<-G2<- Lm_C2[MAC2]                              [1,27,4]
 [0,8,0]   B0<-B1<-B2<- Lm_C3[MAC3]                              [1,27,4]
 */
-void GTE::normalColorColorSingleVector(GTEInstruction instruction) {
-    mac1 = flag.calculateMAC(1, (int64_t)l.v0.x * v0.x + l.v0.y * v0.y + l.v0.z * v0.z) >> (instruction.shiftFraction * 12);
-    mac2 = flag.calculateMAC(2, (int64_t)l.v1.x * v0.x + l.v1.y * v0.y + l.v1.z * v0.z) >> (instruction.shiftFraction * 12);
-    mac3 = flag.calculateMAC(3, (int64_t)l.v2.x * v0.x + l.v2.y * v0.y + l.v2.z * v0.z) >> (instruction.shiftFraction * 12);
+void GTE::normalColorColorSingleVector(GTEInstruction instruction, unsigned int index) {
+    GTEVector3_16_t v = {};
+    switch (index) {
+        case 0: {
+            v = v0;
+            break;
+        }
+        case 1: {
+            v = v1;
+            break;
+        }
+        case 2: {
+            v = v2;
+            break;
+        }
+        default: {
+            logger.logError("Unhandled index in NCCS operation with index: %d", index);
+            break;
+        }
+    }
+    mac1 = flag.calculateMAC(1, (int64_t)l.v0.x * v.x + l.v0.y * v.y + l.v0.z * v.z) >> (instruction.shiftFraction * 12);
+    mac2 = flag.calculateMAC(2, (int64_t)l.v1.x * v.x + l.v1.y * v.y + l.v1.z * v.z) >> (instruction.shiftFraction * 12);
+    mac3 = flag.calculateMAC(3, (int64_t)l.v2.x * v.x + l.v2.y * v.y + l.v2.z * v.z) >> (instruction.shiftFraction * 12);
 
     ir1 = flag.calculateIR(1, mac1, instruction.lm);
     ir2 = flag.calculateIR(2, mac2, instruction.lm);
@@ -1235,4 +1258,29 @@ void GTE::normalColorColorSingleVector(GTEInstruction instruction) {
     rgb2.g = flag.calculateRGB(2, mac2 >> 4);
     rgb2.b = flag.calculateRGB(3, mac3 >> 4);
     rgb2.c = rgbc.c;
+}
+
+/*
+NCCT     39       Normal Color Color triple vector
+Fields:  none
+Opcode:  cop2 $118043F
+
+In:      V0                Normal vector 1                     [1,3,12]
+         V1                Normal vector 2                     [1,3,12]
+         V2                Normal vector 3                     [1,3,12]
+         BK                Background color       RBK,GBK,BBK  [1,19,12]
+         RGB               Primary color          R,G,B,CODE   [0,8,0]
+         LLM               Light matrix                        [1,3,12]
+         LCM               Color matrix                        [1,3,12]
+Out:     RGBn              RGB fifo.              Rn,Gn,Bn,CDn [0,8,0]
+         [IR1,IR2,IR3]     Color vector                        [1,11,4]
+         [MAC1,MAC2,MAC3]  Color vector                        [1,27,4]
+
+Calculation:
+Same as NCCS but repeats for v1 and v2.
+*/
+void GTE::normalColorColorTripleVector(GTEInstruction instruction) {
+    normalColorColorSingleVector(instruction, 0);
+    normalColorColorSingleVector(instruction, 1);
+    normalColorColorSingleVector(instruction, 2);
 }

--- a/src/GTEFlagRegister.cpp
+++ b/src/GTEFlagRegister.cpp
@@ -1,0 +1,107 @@
+#include "GTEFlagRegister.hpp"
+
+void GTEFlagRegister::setMACNegative(unsigned int index) {
+    switch (index) {
+        case 1: {
+            mac1Negative = 1;
+            break;
+        }
+        case 2: {
+            mac2Negative = 1;
+            break;
+        }
+        case 3: {
+            mac3Negative = 1;
+            break;
+        }
+    }
+    return;
+}
+
+void GTEFlagRegister::setMACPositive(unsigned int index) {
+    switch (index) {
+        case 1: {
+            mac1Positive = 1;
+            break;
+        }
+        case 2: {
+            mac2Positive = 1;
+            break;
+        }
+        case 3: {
+            mac3Positive = 1;
+            break;
+        }
+    }
+    return;
+}
+
+void GTEFlagRegister::setIR(unsigned int index) {
+    switch (index) {
+        case 1: {
+            ir1 = 1;
+            break;
+        }
+        case 2: {
+            ir2 = 1;
+            break;
+        }
+        case 3: {
+            ir3 = 1;
+            break;
+        }
+    }
+    return;
+}
+
+int64_t GTEFlagRegister::calculateMAC(unsigned int index, int64_t value) {
+    if (value < -0x80000000000) {
+        setMACNegative(index);
+    }
+    if (value > 0x7FFFFFFFFFF) {
+        setMACPositive(index);
+    }
+
+    return (value << 20) >> 20;
+}
+
+int32_t GTEFlagRegister::calculateMAC0(int64_t value) {
+    if (value < -(int64_t)0x80000000) {
+        mac0Negative = 1;
+    }
+    if (value > 0x7FFFFFFF) {
+        mac0Positive = 1;
+    }
+
+    return value;
+}
+
+int16_t GTEFlagRegister::calculateIR(unsigned int index, int64_t value, bool lm) {
+    if (lm && value < 0) {
+        setIR(index);
+        return 0;
+    }
+    if (!lm && value < -0x8000) {
+        setIR(index);
+        return -0x8000;
+    }
+    if (value > 0x7FFF) {
+        setIR(index);
+        return 0x7FFF;
+    }
+
+    return value;
+}
+
+uint16_t GTEFlagRegister::calculateSZ3(int64_t value) {
+    if (value < 0) {
+        sz3OrOtz = 1;
+        return 0;
+    }
+    if (value > 0xFFFF) {
+        sz3OrOtz = 1;
+        return 0xFFFF;
+    }
+
+    return value;
+}

--- a/src/GTEFlagRegister.cpp
+++ b/src/GTEFlagRegister.cpp
@@ -54,6 +54,24 @@ void GTEFlagRegister::setIR(unsigned int index) {
     return;
 }
 
+void GTEFlagRegister::setRGB(unsigned int index) {
+    switch (index) {
+        case 1: {
+            colorFifoR = 1;
+            break;
+        }
+        case 2: {
+            colorFifoG = 1;
+            break;
+        }
+        case 3: {
+            colorFifoB = 1;
+            break;
+        }
+    }
+    return;
+}
+
 int64_t GTEFlagRegister::calculateMAC(unsigned int index, int64_t value) {
     if (value < -0x80000000000) {
         setMACNegative(index);
@@ -101,6 +119,19 @@ uint16_t GTEFlagRegister::calculateSZ3(int64_t value) {
     if (value > 0xFFFF) {
         sz3OrOtz = 1;
         return 0xFFFF;
+    }
+
+    return value;
+}
+
+uint8_t GTEFlagRegister::calculateRGB(unsigned int index, int value) {
+    if (value < 0) {
+        setRGB(index);
+        return 0;
+    }
+    if (value > 0xFF) {
+        setRGB(index);
+        return 0xFF;
     }
 
     return value;

--- a/src/GTEFlagRegister.cpp
+++ b/src/GTEFlagRegister.cpp
@@ -72,6 +72,20 @@ void GTEFlagRegister::setRGB(unsigned int index) {
     return;
 }
 
+void GTEFlagRegister::setSXY2(unsigned int index) {
+    switch (index) {
+        case 1: {
+            sx2 = 1;
+            break;
+        }
+        case 2: {
+            sy2 = 1;
+            break;
+        }
+    }
+    return;
+}
+
 int64_t GTEFlagRegister::calculateMAC(unsigned int index, int64_t value) {
     if (value < -0x80000000000) {
         setMACNegative(index);
@@ -111,6 +125,20 @@ int16_t GTEFlagRegister::calculateIR(unsigned int index, int64_t value, bool lm)
     return value;
 }
 
+int16_t GTEFlagRegister::calculateIR0(int64_t value) {
+    if (value < 0) {
+        ir0 = 1;
+        return 0;
+    }
+
+    if (value > 0x1000) {
+        ir0 = 1;
+        return 0x1000;
+    }
+
+    return value;
+}
+
 uint16_t GTEFlagRegister::calculateSZ3(int64_t value) {
     if (value < 0) {
         sz3OrOtz = 1;
@@ -132,6 +160,19 @@ uint8_t GTEFlagRegister::calculateRGB(unsigned int index, int value) {
     if (value > 0xFF) {
         setRGB(index);
         return 0xFF;
+    }
+
+    return value;
+}
+
+int16_t GTEFlagRegister::calculateSXY2(unsigned int index, int value) {
+    if (value < -0x400) {
+        setSXY2(index);
+        return -0x400;
+    }
+    if (value > 0x3FF) {
+        setSXY2(index);
+        return 0x3FF;
     }
 
     return value;


### PR DESCRIPTION
The specifications are taken from [ogamespec/pops-gte/docs/gte.txt](https://github.com/ogamespec/pops-gte/blob/master/docs/gte.txt).

Progress:

* [x] Perspective transformation
* [x] Perspective Transformation on 3 points
* [x] Multiply vector by matrix and vector addition (#39)
* [x] Depth Cue Color light
* [x] Depth Cueing (DPCS)
* [x] Interpolation of a vector and far color vector
* [x] Square vector
* [x] Normal color (NCS)
* [x] Normal color (NCT)
* [x] Normal color depth cue single vector
* [x] Normal color depth cue triple vectors
* [x] Depth Cueing (DPCT)
* [x] Normal Color Color single vector
* [x] Normal Color Color triple vector
* [x] Color Depth Que
* [x] Color Color
* [x] Normal clipping
* [x] Average of three Z values
* [x] Average of four Z values
* [x] Outer product of 2 vectors
* [x] General purpose interpolation (GPF)
* [x] General purpose interpolation (GLP)

Result:

![Capture](https://user-images.githubusercontent.com/346590/79205069-c0255b80-7e3d-11ea-89b3-94bf6795fc92.PNG)
