### PR TITLE
Refactor CD-ROM controller

### DIFF
--- a/include/CDROM.tcc
+++ b/include/CDROM.tcc
@@ -65,7 +65,16 @@ inline void CDROM::store(uint32_t offset, T value) {
             break;
         }
         case 1: {
-            execute(value);
+            switch (status.index) {
+                case 0: {
+                    execute(value);
+                    break;
+                }
+                default: {
+                    logger.logWarning("Unhandled CDROM write at offset: %#x, with index: %d", offset, status.index);
+                    break;
+                }
+            }
             break;
         }
         case 2: {


### PR DESCRIPTION
Changes on CD-ROM controller:

* Add CD-ROM interrupt flag register data structure
* Keep track of CD-ROM internal state when synchronizing with the rest of the hardware
* Update status register on register access instead of on status change

with these changes, `caetla` (https://github.com/UnsafePointer/ruby/pull/27) can inspect the CD-ROM file system correctly, displaying:

![Screenshot from 2020-05-05 21-55-29](https://user-images.githubusercontent.com/346590/81388842-305f8e00-9119-11ea-93aa-387924ae9ed6.png)
![Screenshot from 2020-05-05 21-57-09](https://user-images.githubusercontent.com/346590/81388845-3190bb00-9119-11ea-90cf-bf5feb9467a2.png)

instead of:

![Screenshot from 2020-05-08 10-47-56](https://user-images.githubusercontent.com/346590/81388988-669d0d80-9119-11ea-9335-25998ad37004.png)
