### PR TITLE
Fix OpenGL uniforms

### DIFF
--- a/include/RendererProgram.hpp
+++ b/include/RendererProgram.hpp
@@ -15,4 +15,5 @@ public:
 
     void useProgram() const;
     GLuint findProgramAttribute(std::string attribute) const;
+    GLuint findProgramUniform(std::string uniform) const;
 };

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -1824,7 +1824,9 @@ void GPU::operationGp0FillRectagleInVRAM() {
         bottomLeft,
         bottomRight,
     };
+    renderer->setDrawingOffset(0, 0);
     renderer->pushPolygon(vertices);
+    renderer->setDrawingOffset(drawingOffsetX, drawingOffsetY);
     return;
 }
 

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -856,6 +856,7 @@ void GPU::operationGp0SetDrawingAreaTopLeft() {
     uint32_t value = gp0InstructionBuffer[0];
     drawingAreaTop = ((value >> 10) & 0x3ff);
     drawingAreaLeft = (value & 0x3ff);
+    logger.logMessage("GP0(E3h) - Set Drawing Area top left: %d, %d", drawingAreaTop, drawingAreaLeft);
 }
 
 /*
@@ -871,6 +872,7 @@ void GPU::operationGp0SetDrawingAreaBottomRight() {
     uint32_t value = gp0InstructionBuffer[0];
     drawingAreaBottom = ((value >> 10) & 0x3ff);
     drawingAreaRight = (value & 0x3ff);
+    logger.logMessage("GP0(E3h) - Set Drawing Area bottom right: %d, %d", drawingAreaBottom, drawingAreaRight);
 }
 
 /*
@@ -889,6 +891,7 @@ void GPU::operationGp0SetDrawingOffset() {
     int16_t drawingOffsetY = ((int16_t)(y << 5)) >> 5;
 
     renderer->setDrawingOffset(drawingOffsetX, drawingOffsetY);
+    logger.logMessage("GP0(E3h) - Set Drawing Offset: %d, %d", drawingOffsetX, drawingOffsetY);
 }
 
 /*

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -887,8 +887,8 @@ void GPU::operationGp0SetDrawingOffset() {
     uint16_t x = (value & 0x7ff);
     uint16_t y = ((value >> 11) & 0x7ff);
 
-    int16_t drawingOffsetX = ((int16_t)(x << 5)) >> 5;
-    int16_t drawingOffsetY = ((int16_t)(y << 5)) >> 5;
+    drawingOffsetX = ((int16_t)(x << 5)) >> 5;
+    drawingOffsetY = ((int16_t)(y << 5)) >> 5;
 
     renderer->setDrawingOffset(drawingOffsetX, drawingOffsetY);
     logger.logMessage("GP0(E3h) - Set Drawing Offset: %d, %d", drawingOffsetX, drawingOffsetY);

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -23,7 +23,7 @@ Renderer::Renderer(std::unique_ptr<Window> &mainWindow) : logger(LogLevel::NoLog
 
     buffer = make_unique<RendererBuffer<Vertex>>(program, RENDERER_BUFFER_SIZE);
 
-    offsetUniform = program->findProgramAttribute("offset");
+    offsetUniform = program->findProgramUniform("offset");
     glUniform2i(offsetUniform, 0, 0);
 
     // TODO: Use a single vertex shader

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -145,6 +145,8 @@ void Renderer::updateWindowTitle(string title) {
 }
 
 void Renderer::setDrawingOffset(int16_t x, int16_t y) {
+    loadImageTexture->bind(GL_TEXTURE0);
+    Framebuffer framebuffer = Framebuffer(screenTexture);
     buffer->draw(mode);
     glUniform2i(offsetUniform, ((GLint)x), ((GLint)y));
 }

--- a/src/RendererProgram.cpp
+++ b/src/RendererProgram.cpp
@@ -69,3 +69,11 @@ GLuint RendererProgram::findProgramAttribute(string attribute) const {
     rendererDebugger->checkForOpenGLErrors();
     return index;
 }
+
+GLuint RendererProgram::findProgramUniform(std::string uniform) const {
+    const GLchar *attrib = uniform.c_str();
+    GLint index = glGetUniformLocation(program, attrib);
+    RendererDebugger *rendererDebugger = RendererDebugger::getInstance();
+    rendererDebugger->checkForOpenGLErrors();
+    return index;
+}


### PR DESCRIPTION
`glGetAttribLocation` doesn't work for uniforms, so nothing related to drawing offset (GP0 0xe5) ever really worked. 

Before:

![Screenshot from 2020-05-08 15 51 19](https://user-images.githubusercontent.com/346590/81412511-45054b80-9144-11ea-8325-386bde79b758.png)

After:

![Screenshot from 2020-05-08 15 52 11](https://user-images.githubusercontent.com/346590/81412521-46cf0f00-9144-11ea-9826-b0fd5ce5c58d.png)

The changes here fix the problem by using `findProgramUniform` instead, and fix issues introduced by having drawing offset working, like memory transfer commands using absolute addresses not affected by the uniform in the vertex shader.

A nice bonus of this is that the GPU drawing commands are more accurate, but the lack of real drawing area support is more obvious now:

Before:

![Screenshot from 2020-05-08 15 58 11](https://user-images.githubusercontent.com/346590/81412830-be04a300-9144-11ea-99a5-8ac1e5d4a2fe.png)

After:

![Screenshot from 2020-05-08 15 56 57](https://user-images.githubusercontent.com/346590/81412861-ca88fb80-9144-11ea-8fc4-790d679d5d98.png)
