### PR TITLE
Fix GPU drawing area in OpenGL renderer again

### DIFF
--- a/src/EmulatorRunner.cpp
+++ b/src/EmulatorRunner.cpp
@@ -154,6 +154,9 @@ void EmulatorRunner::setup() {
     CPU *cpu = emulator->getCPU();
     cpu->setProgramCounter(programCounter());
     cpu->setGlobalPointer(globalPointer());
-    cpu->setStackPointer(initialStackFramePointerBase() + initialStackFramePointeroffset());
-    cpu->setFramePointer(initialStackFramePointerBase() + initialStackFramePointeroffset());
+    uint32_t stackFramePointerBaseAddress = initialStackFramePointerBase();
+    if (stackFramePointerBaseAddress != 0) {
+        cpu->setStackPointer(stackFramePointerBaseAddress + initialStackFramePointeroffset());
+        cpu->setFramePointer(stackFramePointerBaseAddress + initialStackFramePointeroffset());
+    }
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -108,6 +108,7 @@ void Renderer::applyScissor() {
         y = VRAM_HEIGHT - height - drawingAreaTopLeft.y;
     }
     glScissor(x, y, width, height);
+    glEnable(GL_SCISSOR_TEST);
 }
 
 void Renderer::pushLine(std::vector<Vertex> vertices) {


### PR DESCRIPTION
Small leftover from https://github.com/UnsafePointer/ruby/pull/44

https://github.com/UnsafePointer/ruby/commit/d9b5274efa7b463e9b8b0534e15b55469ac04549 is included to be able to run @JaCzekanski amazing test collection: [JaCzekanski/ps1-tests](https://github.com/JaCzekanski/ps1-tests), I found this bug using [JaCzekanski/ps1-tests/tree/master/gpu/clipping](https://github.com/JaCzekanski/ps1-tests/tree/master/gpu/clipping).

Before:
![bobble2](https://user-images.githubusercontent.com/346590/81724943-743df480-9485-11ea-9878-260cd19069f0.gif)

After:
![bobble1](https://user-images.githubusercontent.com/346590/81725029-8cae0f00-9485-11ea-891a-ea3d64f5b77f.gif)

