### PR TITLE
Implement timer interrupts

### DIFF
--- a/include/CPU.hpp
+++ b/include/CPU.hpp
@@ -7,6 +7,7 @@
 #include "COP0.hpp"
 #include "Logger.hpp"
 #include "GTE.hpp"
+#include "InterruptController.hpp"
 
 struct LoadSlot {
     uint32_t registerIndex;
@@ -47,6 +48,7 @@ class CPU {
     Instruction currentInstruction;
     bool logBiosFunctionCalls;
     std::unique_ptr<GTE> &gte;
+    std::unique_ptr<InterruptController> &interruptController;
 
     void moveLoadDelaySlots();
     void loadDelaySlot(uint32_t registerIndex, uint32_t value);
@@ -141,7 +143,7 @@ class CPU {
 
     void operationIllegal(Instruction instruction);
 public:
-    CPU(LogLevel logLevel, std::unique_ptr<Interconnect> &interconnect, std::unique_ptr<COP0> &cop0, bool logBiosFunctionCalls, std::unique_ptr<GTE> &gte);
+    CPU(LogLevel logLevel, std::unique_ptr<Interconnect> &interconnect, std::unique_ptr<COP0> &cop0, bool logBiosFunctionCalls, std::unique_ptr<GTE> &gte, std::unique_ptr<InterruptController> &interruptController);
     ~CPU();
 
     std::unique_ptr<COP0>& cop0Ref();
@@ -152,6 +154,7 @@ public:
     inline void store(uint32_t address, T value) const;
 
     bool executeNextInstruction();
+    void handleInterrupts();
     // GDB register naming and order used here:
     // r0-r31
     std::array<uint32_t, 32> getRegisters();

--- a/include/InterruptController.hpp
+++ b/include/InterruptController.hpp
@@ -60,22 +60,20 @@ Mask: Read/Write I_MASK (0=Disabled, 1=Enabled)
 */
 class InterruptController {
     Logger logger;
-    std::unique_ptr<COP0> &cop0;
 
     IRQ status;
     IRQ mask;
 
     void setStatus(uint16_t status);
     void setMask(uint16_t mask);
-    bool isActive();
-    void update();
 
     std::string requestNumberDescription(InterruptRequestNumber requestNumber) const;
 public:
-    InterruptController(LogLevel logLevel, std::unique_ptr<COP0> &cop0);
+    InterruptController(LogLevel logLevel);
     ~InterruptController();
 
     void trigger(InterruptRequestNumber irq);
+    bool areInterruptsPending();
 
     template <typename T>
     inline T load(uint32_t offset) const;

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -333,6 +333,7 @@ sub  params  response           ;Effect
 */
 void CDROM::operationTest() {
     uint8_t subfunction = parameters.front();
+    parameters.pop();
     switch (subfunction) {
         case 0x20: {
             pushResponse(0x94); // 148

--- a/src/CDROM.cpp
+++ b/src/CDROM.cpp
@@ -240,6 +240,7 @@ void CDROM::clearResponse() {
 }
 
 void CDROM::pushParameter(uint8_t value) {
+    logger.logMessage("PARAM [W]: %#x", value);
     if (parameters.size() >= 16) {
         logger.logError("Parameter FIFO full");
     }

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -27,7 +27,7 @@ Emulator::Emulator() : logger(LogLevel::NoLog), ttyBuffer() {
     bios = make_unique<BIOS>(configurationManager->biosLogLevel());
     ram = make_unique<RAM>();
     scratchpad = make_unique<Scratchpad>();
-    interruptController = make_unique<InterruptController>(configurationManager->interruptLogLevel(), cop0);
+    interruptController = make_unique<InterruptController>(configurationManager->interruptLogLevel());
     gpu = make_unique<GPU>(configurationManager->gpuLogLevel(), mainWindow, interruptController, debugInfoRenderer);
     LogLevel cdromLogLevel = configurationManager->cdromLogLevel();
     cdrom = make_unique<CDROM>(cdromLogLevel, interruptController);
@@ -40,7 +40,7 @@ Emulator::Emulator() : logger(LogLevel::NoLog), ttyBuffer() {
     spu = make_unique<SPU>(configurationManager->spuLogLevel());
     interconnect = make_unique<Interconnect>(configurationManager->interconnectLogLevel(), cop0, bios, ram, gpu, dma, scratchpad, cdrom, interruptController, expansion1, timer0, timer1, timer2, controller, spu);
     gte = make_unique<GTE>(configurationManager->gteLogLevel());
-    cpu = make_unique<CPU>(configurationManager->cpuLogLevel(), interconnect, cop0, logBiosFunctionCalls, gte);
+    cpu = make_unique<CPU>(configurationManager->cpuLogLevel(), interconnect, cop0, logBiosFunctionCalls, gte, interruptController);
 }
 
 Emulator::~Emulator() {}
@@ -73,6 +73,7 @@ void Emulator::emulateFrame() {
         timer1->step(systemClockStep);
         timer2->step(systemClockStep);
         gpu->step(systemClockStep);
+        cpu->handleInterrupts();
     }
 }
 

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -33,9 +33,9 @@ Emulator::Emulator() : logger(LogLevel::NoLog), ttyBuffer() {
     cdrom = make_unique<CDROM>(cdromLogLevel, interruptController);
     dma = make_unique<DMA>(configurationManager->dmaLogLevel(), ram, gpu, cdrom, interruptController);
     expansion1 = make_unique<Expansion1>();
-    timer0 = make_unique<Timer0>();
-    timer1 = make_unique<Timer1>();
-    timer2 = make_unique<Timer2>();
+    timer0 = make_unique<Timer0>(interruptController);
+    timer1 = make_unique<Timer1>(interruptController);
+    timer2 = make_unique<Timer2>(interruptController);
     controller = make_unique<Controller>(configurationManager->controllerLogLevel(), interruptController);
     spu = make_unique<SPU>(configurationManager->spuLogLevel());
     interconnect = make_unique<Interconnect>(configurationManager->interconnectLogLevel(), cop0, bios, ram, gpu, dma, scratchpad, cdrom, interruptController, expansion1, timer0, timer1, timer2, controller, spu);

--- a/src/InterruptController.cpp
+++ b/src/InterruptController.cpp
@@ -2,7 +2,7 @@
 
 using namespace std;
 
-InterruptController::InterruptController(LogLevel logLevel, unique_ptr<COP0> &cop0) : logger(logLevel, "  IRQ: "), cop0(cop0), status(), mask() {
+InterruptController::InterruptController(LogLevel logLevel) : logger(logLevel, "  IRQ: "), status(), mask() {
 
 }
 
@@ -42,25 +42,16 @@ string InterruptController::requestNumberDescription(InterruptRequestNumber requ
 void InterruptController::trigger(InterruptRequestNumber irq) {
     logger.logMessage("%s interrupt request enabled", requestNumberDescription(irq).c_str());
     status.value |= (1 << irq);
-    update();
 }
 
-bool InterruptController::isActive() {
+bool InterruptController::areInterruptsPending() {
     return (status.value & mask.value) != 0;
 }
 
-void InterruptController::update() {
-    cop0->cause.interruptPending = isActive() ? 4 : 0;
-}
-
 void InterruptController::setStatus(uint16_t status) {
-    this->status.value &= status;
-
-    update();
+    this->status.value &= status & 0x7FF;
 }
 
 void InterruptController::setMask(uint16_t mask) {
-    this->mask.value = mask;
-
-    update();
+    this->mask.value = mask & 0x7FF;
 }


### PR DESCRIPTION
This pull request also contains a small refactor to the way interrupts are handled: `InterruptController` doesn't have a `COP0` reference anymore, instead, marks an internal flag to signal that interrupts are pending and a `CPU` method updates `COP0::CauseRegister` once per hardware synchronization cycle, 300 CPU cycles at the moment.

Crash Bandicoot now boots:

![Screenshot from 2020-05-16 17-35-21](https://user-images.githubusercontent.com/346590/82123823-a4460a00-979b-11ea-9dba-78f04ed5b397.png)
