### PR TITLE
Implement transparency in OpenGL renderer

### DIFF
--- a/glsl/fragment.glsl
+++ b/glsl/fragment.glsl
@@ -3,6 +3,7 @@
 uniform sampler2D frame_buffer_texture;
 
 in vec3 color;
+flat in uint fragment_transparent;
 in vec2 fragment_texture_point;
 flat in uint fragment_texture_blend_mode;
 flat in uvec2 fragment_texture_page;
@@ -63,6 +64,10 @@ void main() {
         }
 
         if (is_transparent(texel)) {
+            discard;
+        }
+
+        if (fragment_transparent == 1) {
             discard;
         }
 

--- a/glsl/fragment.glsl
+++ b/glsl/fragment.glsl
@@ -35,7 +35,7 @@ vec4 get_pixel_from_vram(uint x, uint y) {
 
 void main() {
     if (fragment_texture_blend_mode == BLEND_MODE_NO_TEXTURE) {
-        fragment_color = vec4(color, 1.0);
+        fragment_color = vec4(color, .0);
     } else {
         uint pixel_per_hw = 1U << fragment_texture_depth_shift;
 

--- a/glsl/fragment.glsl
+++ b/glsl/fragment.glsl
@@ -1,6 +1,7 @@
 #version 450 core
 
 uniform sampler2D frame_buffer_texture;
+uniform uint draw_transparent_texture_blend;
 
 in vec3 color;
 flat in uint fragment_transparent;
@@ -67,7 +68,11 @@ void main() {
             discard;
         }
 
-        if (fragment_transparent == 1) {
+        // Bit 15
+        uint transparency_flag = uint(floor(texel.a + 0.5));
+        uint texel_semi_transparent = transparency_flag & fragment_transparent;
+
+        if (texel_semi_transparent != draw_transparent_texture_blend) {
             discard;
         }
 

--- a/glsl/vertex.glsl
+++ b/glsl/vertex.glsl
@@ -2,6 +2,7 @@
 
 in ivec3 vertex_point;
 in uvec3 vertex_color;
+in uint transparent;
 in ivec2 texture_point;
 in uint texture_blend_mode;
 in uvec2 texture_page;
@@ -9,6 +10,7 @@ in uint texture_depth_shift;
 in uvec2 clut;
 
 out vec3 color;
+flat out uint fragment_transparent;
 out vec2 fragment_texture_point;
 flat out uint fragment_texture_blend_mode;
 flat out uvec2 fragment_texture_page;
@@ -31,4 +33,5 @@ void main() {
     fragment_texture_page = texture_page;
     fragment_texture_depth_shift = texture_depth_shift;
     fragment_clut = clut;
+    fragment_transparent = transparent;
 }

--- a/glsl/vertex.glsl
+++ b/glsl/vertex.glsl
@@ -22,8 +22,9 @@ void main() {
 
     float x_pos = (float(position.x) / 512) - 1.0;
     float y_pos = 1.0 - (float(position.y) / 256);
+    float z_pos = 1.0 - (float(vertex_point.z) / 32768);
 
-    gl_Position.xyzw = vec4(x_pos, y_pos, 0.0, 1.0);
+    gl_Position.xyzw = vec4(x_pos, y_pos, z_pos, 1.0);
     color = vec3(float(vertex_color.r) / 255, float(vertex_color.g) / 255, float(vertex_color.b) / 255);
     fragment_texture_point = vec2(texture_point);
     fragment_texture_blend_mode = texture_blend_mode;

--- a/glsl/vertex.glsl
+++ b/glsl/vertex.glsl
@@ -1,6 +1,6 @@
 #version 450 core
 
-in ivec2 vertex_point;
+in ivec3 vertex_point;
 in uvec3 vertex_color;
 in ivec2 texture_point;
 in uint texture_blend_mode;
@@ -18,7 +18,7 @@ flat out uvec2 fragment_clut;
 uniform ivec2 offset;
 
 void main() {
-    ivec2 position = vertex_point + offset;
+    ivec2 position = vertex_point.xy + offset;
 
     float x_pos = (float(position.x) / 512) - 1.0;
     float y_pos = 1.0 - (float(position.y) / 256);

--- a/include/GPU.hpp
+++ b/include/GPU.hpp
@@ -279,8 +279,8 @@ public:
     void executeGp0(uint32_t value);
     void step(uint32_t cycles);
     Dimensions getResolution();
-    Point getDisplayAreaStart();
+    Point2D getDisplayAreaStart();
     Dimensions getDrawingAreaSize();
-    Point getDrawingAreaTopLeft();
+    Point2D getDrawingAreaTopLeft();
     void toggleRenderPolygonOneByOne();
 };

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -46,8 +46,8 @@ public:
     Renderer(std::unique_ptr<Window> &mainWindow, GPU *gpu);
     ~Renderer();
 
-    void pushLine(std::vector<Vertex> vertices);
-    void pushPolygon(std::vector<Vertex> vertices);
+    void pushLine(std::vector<Vertex> vertices, bool opaque);
+    void pushPolygon(std::vector<Vertex> vertices, bool opaque);
     void setDrawingOffset(int16_t x, int16_t y);
     void prepareFrame();
     void renderFrame();

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -24,7 +24,7 @@ class Renderer {
 
     std::unique_ptr<Texture> loadImageTexture;
     std::unique_ptr<RendererProgram> textureRendererProgram;
-    std::unique_ptr<RendererBuffer<Point>> textureBuffer;
+    std::unique_ptr<RendererBuffer<Point2D>> textureBuffer;
 
     std::unique_ptr<Texture> screenTexture;
     std::unique_ptr<RendererProgram> screenRendererProgram;
@@ -32,9 +32,9 @@ class Renderer {
 
     GLenum mode;
     bool resizeToFitFramebuffer;
-    Point displayAreaStart;
+    Point2D displayAreaStart;
     Dimensions screenResolution;
-    Point drawingAreaTopLeft;
+    Point2D drawingAreaTopLeft;
     Dimensions drawingAreaSize;
     bool renderPolygonOneByOne;
 
@@ -55,8 +55,8 @@ public:
     void updateWindowTitle(std::string title);
     void loadImage(std::unique_ptr<GPUImageBuffer> &imageBuffer);
     void resetMainWindow();
-    void setDisplayAreaSart(Point point);
+    void setDisplayAreaSart(Point2D point);
     void setScreenResolution(Dimensions dimensions);
-    void setDrawingArea(Point topLeft, Dimensions size);
+    void setDrawingArea(Point2D topLeft, Dimensions size);
     void toggleRenderPolygonOneByOne();
 };

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -17,6 +17,9 @@ class Renderer {
     Logger logger;
     GLuint offsetUniform;
 
+    std::vector<Vertex> opaqueVertices;
+    std::vector<Vertex> transparentVertices;
+
     std::unique_ptr<Window> &mainWindow;
 
     std::unique_ptr<RendererProgram> program;
@@ -43,6 +46,7 @@ class Renderer {
     void checkForceDraw(unsigned int verticesToRender, GLenum newMode);
     void forceDraw();
     void applyScissor();
+    void insertVertices(std::vector<Vertex> vertices, bool opaque);
 public:
     Renderer(std::unique_ptr<Window> &mainWindow, GPU *gpu);
     ~Renderer();

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -37,6 +37,7 @@ class Renderer {
     Point2D drawingAreaTopLeft;
     Dimensions drawingAreaSize;
     bool renderPolygonOneByOne;
+    uint32_t orderingIndex;
 
     void checkRenderPolygonOneByOne();
     void checkForceDraw(unsigned int verticesToRender, GLenum newMode);

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -16,6 +16,7 @@ class GPU;
 class Renderer {
     Logger logger;
     GLuint offsetUniform;
+    GLuint drawTransparentTextureBlendUniform;
 
     std::vector<Vertex> opaqueVertices;
     std::vector<Vertex> transparentVertices;
@@ -45,13 +46,13 @@ class Renderer {
     void checkRenderPolygonOneByOne();
     void checkForceDraw(unsigned int verticesToRender, GLenum newMode);
     void applyScissor();
-    void insertVertices(std::vector<Vertex> vertices, bool opaque);
+    void insertVertices(std::vector<Vertex> vertices, bool opaque, TextureBlendMode textureBlendMode);
 public:
     Renderer(std::unique_ptr<Window> &mainWindow, GPU *gpu);
     ~Renderer();
 
     void pushLine(std::vector<Vertex> vertices, bool opaque);
-    void pushPolygon(std::vector<Vertex> vertices, bool opaque);
+    void pushPolygon(std::vector<Vertex> vertices, bool opaque, TextureBlendMode textureBlendMode);
     void setDrawingOffset(int16_t x, int16_t y);
     void prepareFrame();
     void renderFrame();

--- a/include/Renderer.hpp
+++ b/include/Renderer.hpp
@@ -44,7 +44,6 @@ class Renderer {
 
     void checkRenderPolygonOneByOne();
     void checkForceDraw(unsigned int verticesToRender, GLenum newMode);
-    void forceDraw();
     void applyScissor();
     void insertVertices(std::vector<Vertex> vertices, bool opaque);
 public:

--- a/include/Vertex.hpp
+++ b/include/Vertex.hpp
@@ -23,6 +23,14 @@ struct Point2D {
     static Point2D forClut(uint16_t clutData);
 };
 
+struct Point3D {
+    GLshort x, y, z;
+
+    Point3D();
+    Point3D(GLshort x, GLshort y, GLshort z);
+    Point3D(uint32_t position);
+};
+
 struct Color {
     GLubyte r, g, b;
 
@@ -36,7 +44,7 @@ enum TextureBlendMode {
 };
 
 struct Vertex {
-    Point2D point;
+    Point3D point;
     Color color;
     Point2D texturePosition;
     GLuint textureBlendMode;
@@ -44,8 +52,8 @@ struct Vertex {
     GLuint textureDepthShift;
     Point2D clut;
 
-    Vertex(Point2D point, Color color);
-    Vertex(Point2D point, Color color, Point2D texturePosition, TextureBlendMode textureBlendMode, Point2D texturePage, GLuint textureDepthShift, Point2D clut);
+    Vertex(Point3D point, Color color);
+    Vertex(Point3D point, Color color, Point2D texturePosition, TextureBlendMode textureBlendMode, Point2D texturePage, GLuint textureDepthShift, Point2D clut);
     ~Vertex();
 };
 

--- a/include/Vertex.hpp
+++ b/include/Vertex.hpp
@@ -46,14 +46,15 @@ enum TextureBlendMode {
 struct Vertex {
     Point3D point;
     Color color;
+    GLuint transparent;
     Point2D texturePosition;
     GLuint textureBlendMode;
     Point2D texturePage;
     GLuint textureDepthShift;
     Point2D clut;
 
-    Vertex(Point3D point, Color color);
-    Vertex(Point3D point, Color color, Point2D texturePosition, TextureBlendMode textureBlendMode, Point2D texturePage, GLuint textureDepthShift, Point2D clut);
+    Vertex(Point3D point, Color color, GLuint opaque);
+    Vertex(Point3D point, Color color, GLuint opaque, Point2D texturePosition, TextureBlendMode textureBlendMode, Point2D texturePage, GLuint textureDepthShift, Point2D clut);
     ~Vertex();
 };
 

--- a/include/Vertex.hpp
+++ b/include/Vertex.hpp
@@ -12,15 +12,15 @@ union Dimensions {
     Dimensions(uint32_t width, uint32_t height) : width(width), height(height) {}
 };
 
-struct Point {
+struct Point2D {
     GLshort x, y;
 
-    Point();
-    Point(GLshort x, GLshort y);
-    Point(uint32_t position);
-    static Point forTexturePosition(uint16_t position);
-    static Point forTexturePage(uint32_t texturePage);
-    static Point forClut(uint16_t clutData);
+    Point2D();
+    Point2D(GLshort x, GLshort y);
+    Point2D(uint32_t position);
+    static Point2D forTexturePosition(uint16_t position);
+    static Point2D forTexturePage(uint32_t texturePage);
+    static Point2D forClut(uint16_t clutData);
 };
 
 struct Color {
@@ -36,16 +36,16 @@ enum TextureBlendMode {
 };
 
 struct Vertex {
-    Point point;
+    Point2D point;
     Color color;
-    Point texturePosition;
+    Point2D texturePosition;
     GLuint textureBlendMode;
-    Point texturePage;
+    Point2D texturePage;
     GLuint textureDepthShift;
-    Point clut;
+    Point2D clut;
 
-    Vertex(Point point, Color color);
-    Vertex(Point point, Color color, Point texturePosition, TextureBlendMode textureBlendMode, Point texturePage, GLuint textureDepthShift, Point clut);
+    Vertex(Point2D point, Color color);
+    Vertex(Point2D point, Color color, Point2D texturePosition, TextureBlendMode textureBlendMode, Point2D texturePage, GLuint textureDepthShift, Point2D clut);
     ~Vertex();
 };
 

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -1856,7 +1856,6 @@ void GPU::operationGp0FillRectagleInVRAM() {
 }
 
 void GPU::texturedQuad(Dimensions dimensions, bool opaque, TextureBlendMode textureBlendMode) {
-    (void)textureBlendMode;
     Color color = Color(gp0InstructionBuffer[0]);
     Point3D point1 = Point3D(gp0InstructionBuffer[1]);
     Point2D texturePoint1 = Point2D::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
@@ -1932,7 +1931,6 @@ void GPU::shadedPolygon(unsigned int numberOfPoints, bool opaque) {
 }
 
 void GPU::texturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlendMode textureBlendMode) {
-    (void)textureBlendMode;
     Color color = Color(gp0InstructionBuffer[0]);
     Point2D clut = Point2D::forClut(gp0InstructionBuffer[2] >> 16);
     Point2D texturePage = Point2D::forTexturePage(gp0InstructionBuffer[4] >> 16);
@@ -1950,7 +1948,6 @@ void GPU::texturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlend
 }
 
 void GPU::shadedTexturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlendMode textureBlendMode) {
-    (void)textureBlendMode;
     Point2D clut = Point2D::forClut(gp0InstructionBuffer[2] >> 16);
     Point2D texturePage = Point2D::forTexturePage(gp0InstructionBuffer[5] >> 16);
     TexturePageColors texturePageColors = texturePageColorsWithValue(((gp0InstructionBuffer[5] >> 16) >> 7) & 0x3);

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -1345,7 +1345,7 @@ GP0(3Eh) - Shaded Textured four-point polygon, semi-transparent, tex-blend
  (12th) Texcoord4        (0000YyXxh) (if any)
 */
 void GPU::operationGp0TexturedShadedFourPointSemiTransparentTextureBlending() {
-    shadedTexturedPolygon(4, true, TextureBlendModeTextureBlend);
+    shadedTexturedPolygon(4, false, TextureBlendModeTextureBlend);
     return;
 }
 
@@ -1850,7 +1850,7 @@ void GPU::operationGp0FillRectagleInVRAM() {
         bottomRight,
     };
     renderer->setDrawingOffset(0, 0);
-    renderer->pushPolygon(vertices, true);
+    renderer->pushPolygon(vertices, true, TextureBlendMode::TextureBlendModeNoTexture);
     renderer->setDrawingOffset(drawingOffsetX, drawingOffsetY);
     return;
 }
@@ -1885,7 +1885,7 @@ void GPU::texturedQuad(Dimensions dimensions, bool opaque, TextureBlendMode text
         Vertex(point3, color, opaque, texturePoint3, textureBlendMode, texturePage, textureDepthShift, clut),
         Vertex(point4, color, opaque, texturePoint4, textureBlendMode, texturePage, textureDepthShift, clut),
     };
-    renderer->pushPolygon(vertices, opaque);
+    renderer->pushPolygon(vertices, opaque, textureBlendMode);
     return;
 }
 
@@ -1906,7 +1906,7 @@ void GPU::quad(Dimensions dimensions, bool opaque) {
         bottomLeft,
         bottomRight,
     };
-    renderer->pushPolygon(vertices, opaque);
+    renderer->pushPolygon(vertices, opaque, TextureBlendMode::TextureBlendModeNoTexture);
     return;
 }
 
@@ -1917,7 +1917,7 @@ void GPU::monochromePolygon(unsigned int numberOfPoints, bool opaque) {
         Point3D point = Point3D(gp0InstructionBuffer[i]);
         vertices.push_back(Vertex(point, color, opaque));
     }
-    renderer->pushPolygon(vertices, opaque);
+    renderer->pushPolygon(vertices, opaque, TextureBlendMode::TextureBlendModeNoTexture);
 }
 
 void GPU::shadedPolygon(unsigned int numberOfPoints, bool opaque) {
@@ -1927,7 +1927,7 @@ void GPU::shadedPolygon(unsigned int numberOfPoints, bool opaque) {
         Point3D point = Point3D(gp0InstructionBuffer[i*2+1]);
         vertices.push_back(Vertex(point, color, opaque));
     }
-    renderer->pushPolygon(vertices, opaque);
+    renderer->pushPolygon(vertices, opaque, TextureBlendMode::TextureBlendModeNoTexture);
 }
 
 void GPU::texturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlendMode textureBlendMode) {
@@ -1944,7 +1944,7 @@ void GPU::texturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlend
         Vertex vertex = Vertex(point, color, opaque, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
         vertices.push_back(vertex);
     }
-    renderer->pushPolygon(vertices, opaque);
+    renderer->pushPolygon(vertices, opaque, textureBlendMode);
 }
 
 void GPU::shadedTexturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlendMode textureBlendMode) {
@@ -1960,7 +1960,7 @@ void GPU::shadedTexturedPolygon(unsigned int numberOfPoints, bool opaque, Textur
         Vertex vertex = Vertex(point, color, opaque, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
         vertices.push_back(vertex);
     }
-    renderer->pushPolygon(vertices, opaque);
+    renderer->pushPolygon(vertices, opaque, textureBlendMode);
 }
 
 void GPU::monochromeLine(unsigned int numberOfPoints, bool opaque) {

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -1831,7 +1831,7 @@ GP0(02h) - Fill Rectangle in VRAM
 */
 void GPU::operationGp0FillRectagleInVRAM() {
     Color color = Color(gp0InstructionBuffer[0]);
-    Point2D point = Point2D(gp0InstructionBuffer[1]);
+    Point3D point = Point3D(gp0InstructionBuffer[1]);
     Dimensions dimentions = Dimensions(gp0InstructionBuffer[2]);
     Vertex topLeft = Vertex(point, color);
     uint32_t width = dimentions.width;
@@ -1860,17 +1860,17 @@ void GPU::texturedQuad(Dimensions dimensions, bool opaque, TextureBlendMode text
     (void)opaque;
     (void)textureBlendMode;
     Color color = Color(gp0InstructionBuffer[0]);
-    Point2D point1 = Point2D(gp0InstructionBuffer[1]);
+    Point3D point1 = Point3D(gp0InstructionBuffer[1]);
     Point2D texturePoint1 = Point2D::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
-    Point2D point2 = Point2D(gp0InstructionBuffer[1]);
+    Point3D point2 = Point3D(gp0InstructionBuffer[1]);
     point2.x += dimensions.width;
     Point2D texturePoint2 = Point2D::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
     texturePoint2.x += dimensions.width;
-    Point2D point3 = Point2D(gp0InstructionBuffer[1]);
+    Point3D point3 = Point3D(gp0InstructionBuffer[1]);
     point3.y += dimensions.height;
     Point2D texturePoint3 = Point2D::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
     texturePoint3.y += dimensions.height;
-    Point2D point4 = Point2D(gp0InstructionBuffer[1]);
+    Point3D point4 = Point3D(gp0InstructionBuffer[1]);
     point4.x += dimensions.width;
     point4.y += dimensions.height;
     Point2D texturePoint4 = Point2D::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
@@ -1896,7 +1896,7 @@ void GPU::quad(Dimensions dimensions, bool opaque) {
     // TODO: unused
     (void)opaque;
     Color color = Color(gp0InstructionBuffer[0]);
-    Point2D point = Point2D(gp0InstructionBuffer[1]);
+    Point3D point = Point3D(gp0InstructionBuffer[1]);
     Vertex topLeft = Vertex(point, color);
     Vertex topRight = Vertex(point, color);
     topRight.point.x += + dimensions.width;
@@ -1921,7 +1921,7 @@ void GPU::monochromePolygon(unsigned int numberOfPoints, bool opaque) {
     Color color = Color(gp0InstructionBuffer[0]);
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 1; i <= numberOfPoints; i++) {
-        Point2D point = Point2D(gp0InstructionBuffer[i]);
+        Point3D point = Point3D(gp0InstructionBuffer[i]);
         vertices.push_back(Vertex(point, color));
     }
     renderer->pushPolygon(vertices);
@@ -1933,7 +1933,7 @@ void GPU::shadedPolygon(unsigned int numberOfPoints, bool opaque) {
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 0; i < numberOfPoints; i++) {
         Color color = Color(gp0InstructionBuffer[i*2]);
-        Point2D point = Point2D(gp0InstructionBuffer[i*2+1]);
+        Point3D point = Point3D(gp0InstructionBuffer[i*2+1]);
         vertices.push_back(Vertex(point, color));
     }
     renderer->pushPolygon(vertices);
@@ -1951,7 +1951,7 @@ void GPU::texturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlend
 
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 0; i < numberOfPoints; i++) {
-        Point2D point = Point2D(gp0InstructionBuffer[i*2+1]);
+        Point3D point = Point3D(gp0InstructionBuffer[i*2+1]);
         Point2D texturePoint = Point2D::forTexturePosition(gp0InstructionBuffer[i*2+2] & 0xffff);
         Vertex vertex = Vertex(point, color, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
         vertices.push_back(vertex);
@@ -1970,7 +1970,7 @@ void GPU::shadedTexturedPolygon(unsigned int numberOfPoints, bool opaque, Textur
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 0; i < numberOfPoints; i++) {
         Color color = Color(gp0InstructionBuffer[i*3]);
-        Point2D point = Point2D(gp0InstructionBuffer[i*3+1]);
+        Point3D point = Point3D(gp0InstructionBuffer[i*3+1]);
         Point2D texturePoint = Point2D::forTexturePosition(gp0InstructionBuffer[i*3+2] & 0xffff);
         Vertex vertex = Vertex(point, color, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
         vertices.push_back(vertex);
@@ -1984,7 +1984,7 @@ void GPU::monochromeLine(unsigned int numberOfPoints, bool opaque) {
     Color color = Color(gp0InstructionBuffer[0]);
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 1; i <= numberOfPoints; i++) {
-        Point2D point = Point2D(gp0InstructionBuffer[i]);
+        Point3D point = Point3D(gp0InstructionBuffer[i]);
         vertices.push_back(Vertex(point, color));
     }
     if (numberOfPoints == 2) {
@@ -2006,7 +2006,7 @@ void GPU::shadedLine(unsigned int numberOfPoints, bool opaque) {
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 0; i < numberOfPoints; i++) {
         Color color = Color(gp0InstructionBuffer[i*2]);
-        Point2D point = Point2D(gp0InstructionBuffer[i*2+1]);
+        Point3D point = Point3D(gp0InstructionBuffer[i*2+1]);
         vertices.push_back(Vertex(point, color));
     }
     if (numberOfPoints == 2) {

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -1833,14 +1833,14 @@ void GPU::operationGp0FillRectagleInVRAM() {
     Color color = Color(gp0InstructionBuffer[0]);
     Point3D point = Point3D(gp0InstructionBuffer[1]);
     Dimensions dimentions = Dimensions(gp0InstructionBuffer[2]);
-    Vertex topLeft = Vertex(point, color);
+    Vertex topLeft = Vertex(point, color, true);
     uint32_t width = dimentions.width;
     uint32_t height = dimentions.height;
-    Vertex topRight = Vertex(gp0InstructionBuffer[1], color);
+    Vertex topRight = Vertex(gp0InstructionBuffer[1], color, true);
     topRight.point.x = topRight.point.x + width;
-    Vertex bottomLeft = Vertex(gp0InstructionBuffer[1], color);
+    Vertex bottomLeft = Vertex(gp0InstructionBuffer[1], color, true);
     bottomLeft.point.y = bottomLeft.point.y + height;
-    Vertex bottomRight = Vertex(gp0InstructionBuffer[1], color);
+    Vertex bottomRight = Vertex(gp0InstructionBuffer[1], color, true);
     bottomRight.point.x = bottomRight.point.x + width;
     bottomRight.point.y = bottomRight.point.y + height;
     vector<Vertex> vertices = {
@@ -1880,10 +1880,10 @@ void GPU::texturedQuad(Dimensions dimensions, bool opaque, TextureBlendMode text
     GLuint textureDepthShift = 2 - texturePageColors;
     Point2D clut = Point2D::forClut(gp0InstructionBuffer[2] >> 16);
     vector<Vertex> vertices = {
-        Vertex(point1, color, texturePoint1, textureBlendMode, texturePage, textureDepthShift, clut),
-        Vertex(point2, color, texturePoint2, textureBlendMode, texturePage, textureDepthShift, clut),
-        Vertex(point3, color, texturePoint3, textureBlendMode, texturePage, textureDepthShift, clut),
-        Vertex(point4, color, texturePoint4, textureBlendMode, texturePage, textureDepthShift, clut),
+        Vertex(point1, color, opaque, texturePoint1, textureBlendMode, texturePage, textureDepthShift, clut),
+        Vertex(point2, color, opaque, texturePoint2, textureBlendMode, texturePage, textureDepthShift, clut),
+        Vertex(point3, color, opaque, texturePoint3, textureBlendMode, texturePage, textureDepthShift, clut),
+        Vertex(point4, color, opaque, texturePoint4, textureBlendMode, texturePage, textureDepthShift, clut),
     };
     renderer->pushPolygon(vertices, opaque);
     return;
@@ -1892,12 +1892,12 @@ void GPU::texturedQuad(Dimensions dimensions, bool opaque, TextureBlendMode text
 void GPU::quad(Dimensions dimensions, bool opaque) {
     Color color = Color(gp0InstructionBuffer[0]);
     Point3D point = Point3D(gp0InstructionBuffer[1]);
-    Vertex topLeft = Vertex(point, color);
-    Vertex topRight = Vertex(point, color);
+    Vertex topLeft = Vertex(point, color, opaque);
+    Vertex topRight = Vertex(point, color, opaque);
     topRight.point.x += + dimensions.width;
-    Vertex bottomLeft = Vertex(point, color);
+    Vertex bottomLeft = Vertex(point, color, opaque);
     bottomLeft.point.y += dimensions.height;
-    Vertex bottomRight = Vertex(point, color);
+    Vertex bottomRight = Vertex(point, color, opaque);
     bottomRight.point.x += dimensions.width;
     bottomRight.point.y += dimensions.height;
     vector<Vertex> vertices = {
@@ -1915,7 +1915,7 @@ void GPU::monochromePolygon(unsigned int numberOfPoints, bool opaque) {
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 1; i <= numberOfPoints; i++) {
         Point3D point = Point3D(gp0InstructionBuffer[i]);
-        vertices.push_back(Vertex(point, color));
+        vertices.push_back(Vertex(point, color, opaque));
     }
     renderer->pushPolygon(vertices, opaque);
 }
@@ -1925,7 +1925,7 @@ void GPU::shadedPolygon(unsigned int numberOfPoints, bool opaque) {
     for (unsigned int i = 0; i < numberOfPoints; i++) {
         Color color = Color(gp0InstructionBuffer[i*2]);
         Point3D point = Point3D(gp0InstructionBuffer[i*2+1]);
-        vertices.push_back(Vertex(point, color));
+        vertices.push_back(Vertex(point, color, opaque));
     }
     renderer->pushPolygon(vertices, opaque);
 }
@@ -1941,7 +1941,7 @@ void GPU::texturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlend
     for (unsigned int i = 0; i < numberOfPoints; i++) {
         Point3D point = Point3D(gp0InstructionBuffer[i*2+1]);
         Point2D texturePoint = Point2D::forTexturePosition(gp0InstructionBuffer[i*2+2] & 0xffff);
-        Vertex vertex = Vertex(point, color, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
+        Vertex vertex = Vertex(point, color, opaque, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
         vertices.push_back(vertex);
     }
     renderer->pushPolygon(vertices, opaque);
@@ -1957,7 +1957,7 @@ void GPU::shadedTexturedPolygon(unsigned int numberOfPoints, bool opaque, Textur
         Color color = Color(gp0InstructionBuffer[i*3]);
         Point3D point = Point3D(gp0InstructionBuffer[i*3+1]);
         Point2D texturePoint = Point2D::forTexturePosition(gp0InstructionBuffer[i*3+2] & 0xffff);
-        Vertex vertex = Vertex(point, color, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
+        Vertex vertex = Vertex(point, color, opaque, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
         vertices.push_back(vertex);
     }
     renderer->pushPolygon(vertices, opaque);
@@ -1968,7 +1968,7 @@ void GPU::monochromeLine(unsigned int numberOfPoints, bool opaque) {
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 1; i <= numberOfPoints; i++) {
         Point3D point = Point3D(gp0InstructionBuffer[i]);
-        vertices.push_back(Vertex(point, color));
+        vertices.push_back(Vertex(point, color, opaque));
     }
     if (numberOfPoints == 2) {
         renderer->pushLine(vertices, opaque);
@@ -1988,7 +1988,7 @@ void GPU::shadedLine(unsigned int numberOfPoints, bool opaque) {
     for (unsigned int i = 0; i < numberOfPoints; i++) {
         Color color = Color(gp0InstructionBuffer[i*2]);
         Point3D point = Point3D(gp0InstructionBuffer[i*2+1]);
-        vertices.push_back(Vertex(point, color));
+        vertices.push_back(Vertex(point, color, opaque));
     }
     if (numberOfPoints == 2) {
         renderer->pushLine(vertices, opaque);

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -631,7 +631,7 @@ void GPU::render() {
 }
 
 void GPU::updateDrawingArea() {
-    Point topLeft = getDrawingAreaTopLeft();
+    Point2D topLeft = getDrawingAreaTopLeft();
     Dimensions size = getDrawingAreaSize();
     logger.logMessage("Updating renderer drawing area with top left: x=%d, y=%d and size: w=%d, h=%d", topLeft.x, topLeft.y, size.width, size.height);
     renderer->setDrawingArea(topLeft, size);
@@ -665,7 +665,7 @@ Dimensions GPU::getResolution() {
     return { 0, 0 };
 }
 
-Point GPU::getDisplayAreaStart() {
+Point2D GPU::getDisplayAreaStart() {
     return { (int16_t)displayVRAMStartX, (int16_t)displayVRAMStartY };
 }
 
@@ -675,7 +675,7 @@ Dimensions GPU::getDrawingAreaSize() {
     return { (uint32_t)width, (uint32_t)height };
 }
 
-Point GPU::getDrawingAreaTopLeft() {
+Point2D GPU::getDrawingAreaTopLeft() {
     return { (int16_t)drawingAreaLeft, (int16_t)drawingAreaTop };
 }
 
@@ -996,7 +996,7 @@ GP0(A0h) - Copy Rectangle (CPU to VRAM)
 ...  Data              (...)      <--- usually transferred via DMA
 */
 void GPU::operationGp0CopyRectangleCPUToVRAM() {
-    Point point = Point(gp0InstructionBuffer[1]);
+    Point2D point = Point2D(gp0InstructionBuffer[1]);
     Dimensions dimensions = Dimensions(gp0InstructionBuffer[2]);
     uint32_t imageSize = dimensions.width * dimensions.height;
     // Pixels are 16 bit wide and transactions are 32 bit wide
@@ -1831,7 +1831,7 @@ GP0(02h) - Fill Rectangle in VRAM
 */
 void GPU::operationGp0FillRectagleInVRAM() {
     Color color = Color(gp0InstructionBuffer[0]);
-    Point point = Point(gp0InstructionBuffer[1]);
+    Point2D point = Point2D(gp0InstructionBuffer[1]);
     Dimensions dimentions = Dimensions(gp0InstructionBuffer[2]);
     Vertex topLeft = Vertex(point, color);
     uint32_t width = dimentions.width;
@@ -1860,28 +1860,28 @@ void GPU::texturedQuad(Dimensions dimensions, bool opaque, TextureBlendMode text
     (void)opaque;
     (void)textureBlendMode;
     Color color = Color(gp0InstructionBuffer[0]);
-    Point point1 = Point(gp0InstructionBuffer[1]);
-    Point texturePoint1 = Point::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
-    Point point2 = Point(gp0InstructionBuffer[1]);
+    Point2D point1 = Point2D(gp0InstructionBuffer[1]);
+    Point2D texturePoint1 = Point2D::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
+    Point2D point2 = Point2D(gp0InstructionBuffer[1]);
     point2.x += dimensions.width;
-    Point texturePoint2 = Point::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
+    Point2D texturePoint2 = Point2D::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
     texturePoint2.x += dimensions.width;
-    Point point3 = Point(gp0InstructionBuffer[1]);
+    Point2D point3 = Point2D(gp0InstructionBuffer[1]);
     point3.y += dimensions.height;
-    Point texturePoint3 = Point::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
+    Point2D texturePoint3 = Point2D::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
     texturePoint3.y += dimensions.height;
-    Point point4 = Point(gp0InstructionBuffer[1]);
+    Point2D point4 = Point2D(gp0InstructionBuffer[1]);
     point4.x += dimensions.width;
     point4.y += dimensions.height;
-    Point texturePoint4 = Point::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
+    Point2D texturePoint4 = Point2D::forTexturePosition(gp0InstructionBuffer[2] & 0xffff);
     texturePoint4.x += dimensions.width;
     texturePoint4.y += dimensions.height;
     uint16_t texturePageData = texturePageBaseY;
     texturePageData <<= 4;
     texturePageData |= texturePageBaseX;
-    Point texturePage = Point::forTexturePage(texturePageData);
+    Point2D texturePage = Point2D::forTexturePage(texturePageData);
     GLuint textureDepthShift = 2 - texturePageColors;
-    Point clut = Point::forClut(gp0InstructionBuffer[2] >> 16);
+    Point2D clut = Point2D::forClut(gp0InstructionBuffer[2] >> 16);
     vector<Vertex> vertices = {
         Vertex(point1, color, texturePoint1, textureBlendMode, texturePage, textureDepthShift, clut),
         Vertex(point2, color, texturePoint2, textureBlendMode, texturePage, textureDepthShift, clut),
@@ -1896,7 +1896,7 @@ void GPU::quad(Dimensions dimensions, bool opaque) {
     // TODO: unused
     (void)opaque;
     Color color = Color(gp0InstructionBuffer[0]);
-    Point point = Point(gp0InstructionBuffer[1]);
+    Point2D point = Point2D(gp0InstructionBuffer[1]);
     Vertex topLeft = Vertex(point, color);
     Vertex topRight = Vertex(point, color);
     topRight.point.x += + dimensions.width;
@@ -1921,7 +1921,7 @@ void GPU::monochromePolygon(unsigned int numberOfPoints, bool opaque) {
     Color color = Color(gp0InstructionBuffer[0]);
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 1; i <= numberOfPoints; i++) {
-        Point point = Point(gp0InstructionBuffer[i]);
+        Point2D point = Point2D(gp0InstructionBuffer[i]);
         vertices.push_back(Vertex(point, color));
     }
     renderer->pushPolygon(vertices);
@@ -1933,7 +1933,7 @@ void GPU::shadedPolygon(unsigned int numberOfPoints, bool opaque) {
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 0; i < numberOfPoints; i++) {
         Color color = Color(gp0InstructionBuffer[i*2]);
-        Point point = Point(gp0InstructionBuffer[i*2+1]);
+        Point2D point = Point2D(gp0InstructionBuffer[i*2+1]);
         vertices.push_back(Vertex(point, color));
     }
     renderer->pushPolygon(vertices);
@@ -1944,15 +1944,15 @@ void GPU::texturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlend
     (void)opaque;
     (void)textureBlendMode;
     Color color = Color(gp0InstructionBuffer[0]);
-    Point clut = Point::forClut(gp0InstructionBuffer[2] >> 16);
-    Point texturePage = Point::forTexturePage(gp0InstructionBuffer[4] >> 16);
+    Point2D clut = Point2D::forClut(gp0InstructionBuffer[2] >> 16);
+    Point2D texturePage = Point2D::forTexturePage(gp0InstructionBuffer[4] >> 16);
     TexturePageColors texturePageColors = texturePageColorsWithValue(((gp0InstructionBuffer[4] >> 16) >> 7) & 0x3);
     GLuint textureDepthShift = 2 - texturePageColors;
 
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 0; i < numberOfPoints; i++) {
-        Point point = Point(gp0InstructionBuffer[i*2+1]);
-        Point texturePoint = Point::forTexturePosition(gp0InstructionBuffer[i*2+2] & 0xffff);
+        Point2D point = Point2D(gp0InstructionBuffer[i*2+1]);
+        Point2D texturePoint = Point2D::forTexturePosition(gp0InstructionBuffer[i*2+2] & 0xffff);
         Vertex vertex = Vertex(point, color, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
         vertices.push_back(vertex);
     }
@@ -1963,15 +1963,15 @@ void GPU::shadedTexturedPolygon(unsigned int numberOfPoints, bool opaque, Textur
     // TODO: unused
     (void)opaque;
     (void)textureBlendMode;
-    Point clut = Point::forClut(gp0InstructionBuffer[2] >> 16);
-    Point texturePage = Point::forTexturePage(gp0InstructionBuffer[5] >> 16);
+    Point2D clut = Point2D::forClut(gp0InstructionBuffer[2] >> 16);
+    Point2D texturePage = Point2D::forTexturePage(gp0InstructionBuffer[5] >> 16);
     TexturePageColors texturePageColors = texturePageColorsWithValue(((gp0InstructionBuffer[5] >> 16) >> 7) & 0x3);
     GLuint textureDepthShift = 2 - texturePageColors;
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 0; i < numberOfPoints; i++) {
         Color color = Color(gp0InstructionBuffer[i*3]);
-        Point point = Point(gp0InstructionBuffer[i*3+1]);
-        Point texturePoint = Point::forTexturePosition(gp0InstructionBuffer[i*3+2] & 0xffff);
+        Point2D point = Point2D(gp0InstructionBuffer[i*3+1]);
+        Point2D texturePoint = Point2D::forTexturePosition(gp0InstructionBuffer[i*3+2] & 0xffff);
         Vertex vertex = Vertex(point, color, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
         vertices.push_back(vertex);
     }
@@ -1984,7 +1984,7 @@ void GPU::monochromeLine(unsigned int numberOfPoints, bool opaque) {
     Color color = Color(gp0InstructionBuffer[0]);
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 1; i <= numberOfPoints; i++) {
-        Point point = Point(gp0InstructionBuffer[i]);
+        Point2D point = Point2D(gp0InstructionBuffer[i]);
         vertices.push_back(Vertex(point, color));
     }
     if (numberOfPoints == 2) {
@@ -2006,7 +2006,7 @@ void GPU::shadedLine(unsigned int numberOfPoints, bool opaque) {
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 0; i < numberOfPoints; i++) {
         Color color = Color(gp0InstructionBuffer[i*2]);
-        Point point = Point(gp0InstructionBuffer[i*2+1]);
+        Point2D point = Point2D(gp0InstructionBuffer[i*2+1]);
         vertices.push_back(Vertex(point, color));
     }
     if (numberOfPoints == 2) {

--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -1850,14 +1850,12 @@ void GPU::operationGp0FillRectagleInVRAM() {
         bottomRight,
     };
     renderer->setDrawingOffset(0, 0);
-    renderer->pushPolygon(vertices);
+    renderer->pushPolygon(vertices, true);
     renderer->setDrawingOffset(drawingOffsetX, drawingOffsetY);
     return;
 }
 
 void GPU::texturedQuad(Dimensions dimensions, bool opaque, TextureBlendMode textureBlendMode) {
-    // TODO: unused
-    (void)opaque;
     (void)textureBlendMode;
     Color color = Color(gp0InstructionBuffer[0]);
     Point3D point1 = Point3D(gp0InstructionBuffer[1]);
@@ -1888,13 +1886,11 @@ void GPU::texturedQuad(Dimensions dimensions, bool opaque, TextureBlendMode text
         Vertex(point3, color, texturePoint3, textureBlendMode, texturePage, textureDepthShift, clut),
         Vertex(point4, color, texturePoint4, textureBlendMode, texturePage, textureDepthShift, clut),
     };
-    renderer->pushPolygon(vertices);
+    renderer->pushPolygon(vertices, opaque);
     return;
 }
 
 void GPU::quad(Dimensions dimensions, bool opaque) {
-    // TODO: unused
-    (void)opaque;
     Color color = Color(gp0InstructionBuffer[0]);
     Point3D point = Point3D(gp0InstructionBuffer[1]);
     Vertex topLeft = Vertex(point, color);
@@ -1911,37 +1907,31 @@ void GPU::quad(Dimensions dimensions, bool opaque) {
         bottomLeft,
         bottomRight,
     };
-    renderer->pushPolygon(vertices);
+    renderer->pushPolygon(vertices, opaque);
     return;
 }
 
 void GPU::monochromePolygon(unsigned int numberOfPoints, bool opaque) {
-    // TODO: unused
-    (void)opaque;
     Color color = Color(gp0InstructionBuffer[0]);
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 1; i <= numberOfPoints; i++) {
         Point3D point = Point3D(gp0InstructionBuffer[i]);
         vertices.push_back(Vertex(point, color));
     }
-    renderer->pushPolygon(vertices);
+    renderer->pushPolygon(vertices, opaque);
 }
 
 void GPU::shadedPolygon(unsigned int numberOfPoints, bool opaque) {
-    // TODO: unused
-    (void)opaque;
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 0; i < numberOfPoints; i++) {
         Color color = Color(gp0InstructionBuffer[i*2]);
         Point3D point = Point3D(gp0InstructionBuffer[i*2+1]);
         vertices.push_back(Vertex(point, color));
     }
-    renderer->pushPolygon(vertices);
+    renderer->pushPolygon(vertices, opaque);
 }
 
 void GPU::texturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlendMode textureBlendMode) {
-    // TODO: unused
-    (void)opaque;
     (void)textureBlendMode;
     Color color = Color(gp0InstructionBuffer[0]);
     Point2D clut = Point2D::forClut(gp0InstructionBuffer[2] >> 16);
@@ -1956,12 +1946,10 @@ void GPU::texturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlend
         Vertex vertex = Vertex(point, color, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
         vertices.push_back(vertex);
     }
-    renderer->pushPolygon(vertices);
+    renderer->pushPolygon(vertices, opaque);
 }
 
 void GPU::shadedTexturedPolygon(unsigned int numberOfPoints, bool opaque, TextureBlendMode textureBlendMode) {
-    // TODO: unused
-    (void)opaque;
     (void)textureBlendMode;
     Point2D clut = Point2D::forClut(gp0InstructionBuffer[2] >> 16);
     Point2D texturePage = Point2D::forTexturePage(gp0InstructionBuffer[5] >> 16);
@@ -1975,12 +1963,10 @@ void GPU::shadedTexturedPolygon(unsigned int numberOfPoints, bool opaque, Textur
         Vertex vertex = Vertex(point, color, texturePoint, textureBlendMode, texturePage, textureDepthShift, clut);
         vertices.push_back(vertex);
     }
-    renderer->pushPolygon(vertices);
+    renderer->pushPolygon(vertices, opaque);
 }
 
 void GPU::monochromeLine(unsigned int numberOfPoints, bool opaque) {
-    // TODO: unused
-    (void)opaque;
     Color color = Color(gp0InstructionBuffer[0]);
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 1; i <= numberOfPoints; i++) {
@@ -1988,21 +1974,19 @@ void GPU::monochromeLine(unsigned int numberOfPoints, bool opaque) {
         vertices.push_back(Vertex(point, color));
     }
     if (numberOfPoints == 2) {
-        renderer->pushLine(vertices);
+        renderer->pushLine(vertices, opaque);
         return;
     }
     vector<Vertex> lines = vector<Vertex>();
     for (unsigned int i = 0; i < vertices.size() - 1; i++) {
         lines.push_back(vertices[i]);
         lines.push_back(vertices[i+1]);
-        renderer->pushLine(lines);
+        renderer->pushLine(lines, opaque);
         lines.clear();
     }
 }
 
 void GPU::shadedLine(unsigned int numberOfPoints, bool opaque) {
-    // TODO: unused
-    (void)opaque;
     vector<Vertex> vertices = vector<Vertex>();
     for (unsigned int i = 0; i < numberOfPoints; i++) {
         Color color = Color(gp0InstructionBuffer[i*2]);
@@ -2010,14 +1994,14 @@ void GPU::shadedLine(unsigned int numberOfPoints, bool opaque) {
         vertices.push_back(Vertex(point, color));
     }
     if (numberOfPoints == 2) {
-        renderer->pushLine(vertices);
+        renderer->pushLine(vertices, opaque);
         return;
     }
     vector<Vertex> lines = vector<Vertex>();
     for (unsigned int i = 0; i < vertices.size() - 1; i++) {
         lines.push_back(vertices[i]);
         lines.push_back(vertices[i+1]);
-        renderer->pushLine(lines);
+        renderer->pushLine(lines, opaque);
         lines.clear();
     }
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -188,17 +188,30 @@ void Renderer::prepareFrame() {
     resetMainWindow();
     applyScissor();
     glEnable(GL_SCISSOR_TEST);
+    glBlendColor(0.25, 0.25, 0.25, 0.5);
 }
 
 void Renderer::renderFrame() {
     loadImageTexture->bind(GL_TEXTURE0);
+
     Framebuffer framebuffer = Framebuffer(screenTexture);
+
+    glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_ONE, GL_ZERO);
+    glDisable(GL_BLEND);
+
     buffer->addData(opaqueVertices);
-    buffer->addData(transparentVertices);
     opaqueVertices.clear();
+    buffer->draw(mode);
+
+    glBlendFuncSeparate(GL_CONSTANT_ALPHA, GL_CONSTANT_ALPHA, GL_ONE, GL_ZERO);
+    glBlendEquationSeparate(GL_FUNC_ADD, GL_FUNC_ADD);
+    glEnable(GL_BLEND);
+
+    buffer->addData(transparentVertices);
     transparentVertices.clear();
     buffer->draw(mode);
     orderingIndex = 0;
+
     RendererDebugger *rendererDebugger = RendererDebugger::getInstance();
     rendererDebugger->checkForOpenGLErrors();
 }
@@ -206,6 +219,8 @@ void Renderer::renderFrame() {
 void Renderer::finalizeFrame() {
     screenTexture->bind(GL_TEXTURE0);
     glDisable(GL_SCISSOR_TEST);
+    glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_ONE, GL_ZERO);
+    glDisable(GL_BLEND);
     vector<Pixel> pixels;
     if (resizeToFitFramebuffer) {
         pixels = {

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -16,7 +16,7 @@ Renderer::Renderer(std::unique_ptr<Window> &mainWindow, GPU *gpu) : logger(LogLe
 
     textureRendererProgram = make_unique<RendererProgram>("./glsl/texture_load_vertex.glsl", "./glsl/texture_load_fragment.glsl");
 
-    textureBuffer = make_unique<RendererBuffer<Point>>(textureRendererProgram, RENDERER_BUFFER_SIZE);
+    textureBuffer = make_unique<RendererBuffer<Point2D>>(textureRendererProgram, RENDERER_BUFFER_SIZE);
 
     program = make_unique<RendererProgram>("glsl/vertex.glsl", "glsl/fragment.glsl");
     program->useProgram();
@@ -153,7 +153,7 @@ void Renderer::resetMainWindow() {
     mainWindow->makeCurrent();
 }
 
-void Renderer::setDisplayAreaSart(Point point) {
+void Renderer::setDisplayAreaSart(Point2D point) {
     displayAreaStart = point;
 }
 
@@ -161,7 +161,7 @@ void Renderer::setScreenResolution(Dimensions dimensions) {
     screenResolution = dimensions;
 }
 
-void Renderer::setDrawingArea(Point topLeft, Dimensions size) {
+void Renderer::setDrawingArea(Point2D topLeft, Dimensions size) {
     forceDraw();
 
     drawingAreaTopLeft = topLeft;
@@ -231,7 +231,7 @@ void Renderer::loadImage(std::unique_ptr<GPUImageBuffer> &imageBuffer) {
     uint16_t x, y, width, height;
     tie(x, y) = imageBuffer->destination();
     tie(width, height) = imageBuffer->resolution();
-    vector<Point> data = { {(GLshort)x, (GLshort)y}, {(GLshort)(x + width), (GLshort)y}, {(GLshort)x, (GLshort)(y + height)}, {(GLshort)(x + width), (GLshort)(y + height)} };
+    vector<Point2D> data = { {(GLshort)x, (GLshort)y}, {(GLshort)(x + width), (GLshort)y}, {(GLshort)x, (GLshort)(y + height)}, {(GLshort)(x + width), (GLshort)(y + height)} };
     textureBuffer->addData(data);
     glDisable(GL_SCISSOR_TEST);
     Framebuffer framebuffer = Framebuffer(screenTexture);

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -75,23 +75,12 @@ void Renderer::checkForceDraw(unsigned int verticesToRender, GLenum newMode) {
         verticesToRenderTotal = 6;
     }
     if (buffer->remainingCapacity() < verticesToRenderTotal) {
-        forceDraw();
+        renderFrame();
     }
     if (mode != newMode) {
-        forceDraw();
+        renderFrame();
     }
     return;
-}
-
-void Renderer::forceDraw() {
-    loadImageTexture->bind(GL_TEXTURE0);
-    Framebuffer framebuffer = Framebuffer(screenTexture);
-    buffer->addData(opaqueVertices);
-    buffer->addData(transparentVertices);
-    opaqueVertices.clear();
-    transparentVertices.clear();
-    buffer->draw(mode);
-    orderingIndex = 0;
 }
 
 void Renderer::applyScissor() {
@@ -183,7 +172,7 @@ void Renderer::setScreenResolution(Dimensions dimensions) {
 }
 
 void Renderer::setDrawingArea(Point2D topLeft, Dimensions size) {
-    forceDraw();
+    renderFrame();
 
     drawingAreaTopLeft = topLeft;
     drawingAreaSize = size;
@@ -199,10 +188,10 @@ void Renderer::prepareFrame() {
     resetMainWindow();
     applyScissor();
     glEnable(GL_SCISSOR_TEST);
-    loadImageTexture->bind(GL_TEXTURE0);
 }
 
 void Renderer::renderFrame() {
+    loadImageTexture->bind(GL_TEXTURE0);
     Framebuffer framebuffer = Framebuffer(screenTexture);
     buffer->addData(opaqueVertices);
     buffer->addData(transparentVertices);
@@ -215,12 +204,6 @@ void Renderer::renderFrame() {
 }
 
 void Renderer::finalizeFrame() {
-    buffer->addData(opaqueVertices);
-    buffer->addData(transparentVertices);
-    opaqueVertices.clear();
-    transparentVertices.clear();
-    buffer->draw(mode);
-    orderingIndex = 0;
     screenTexture->bind(GL_TEXTURE0);
     glDisable(GL_SCISSOR_TEST);
     vector<Pixel> pixels;
@@ -252,7 +235,7 @@ void Renderer::updateWindowTitle(string title) {
 }
 
 void Renderer::setDrawingOffset(int16_t x, int16_t y) {
-    forceDraw();
+    renderFrame();
     glUniform2i(offsetUniform, ((GLint)x), ((GLint)y));
 }
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -111,7 +111,9 @@ void Renderer::applyScissor() {
     glEnable(GL_SCISSOR_TEST);
 }
 
-void Renderer::pushLine(std::vector<Vertex> vertices) {
+void Renderer::pushLine(std::vector<Vertex> vertices, bool opaque) {
+    // TODO: unused
+    (void)opaque;
     unsigned int size = vertices.size();
     if (size < 2) {
         logger.logError("Unhandled line with %d vertices", size);
@@ -124,7 +126,9 @@ void Renderer::pushLine(std::vector<Vertex> vertices) {
     return;
 }
 
-void Renderer::pushPolygon(std::vector<Vertex> vertices) {
+void Renderer::pushPolygon(std::vector<Vertex> vertices, bool opaque) {
+    // TODO: unused
+    (void)opaque;
     unsigned int size = vertices.size();
     if (size < 3 || size > 4) {
         logger.logError("Unhandled polygon with %d vertices", size);

--- a/src/RendererBuffer.cpp
+++ b/src/RendererBuffer.cpp
@@ -102,7 +102,7 @@ void RendererBuffer<Vertex>::enableAttributes() const {
 }
 
 template <>
-void RendererBuffer<Point>::enableAttributes() const {
+void RendererBuffer<Point2D>::enableAttributes() const {
     GLuint positionIdx = program->findProgramAttribute("position");
     glVertexAttribIPointer(positionIdx, 2, GL_SHORT, 0, NULL);
     glEnableVertexAttribArray(positionIdx);
@@ -119,5 +119,5 @@ void RendererBuffer<Pixel>::enableAttributes() const {
 }
 
 template class RendererBuffer<Vertex>;
-template class RendererBuffer<Point>;
+template class RendererBuffer<Point2D>;
 template class RendererBuffer<Pixel>;

--- a/src/RendererBuffer.cpp
+++ b/src/RendererBuffer.cpp
@@ -80,6 +80,10 @@ void RendererBuffer<Vertex>::enableAttributes() const {
     glVertexAttribIPointer(colorIdx, 3, GL_UNSIGNED_BYTE, sizeof(Vertex), (void*)offsetof(struct Vertex, color));
     glEnableVertexAttribArray(colorIdx);
 
+    GLuint transparentPositionIdx = program->findProgramAttribute("transparent");
+    glVertexAttribIPointer(transparentPositionIdx, 1, GL_UNSIGNED_INT, sizeof(Vertex), (void*)offsetof(struct Vertex, transparent));
+    glEnableVertexAttribArray(transparentPositionIdx);
+
     GLuint texturePositionIdx = program->findProgramAttribute("texture_point");
     glVertexAttribIPointer(texturePositionIdx, 2, GL_SHORT, sizeof(Vertex), (void*)offsetof(struct Vertex, texturePosition));
     glEnableVertexAttribArray(texturePositionIdx);

--- a/src/RendererBuffer.cpp
+++ b/src/RendererBuffer.cpp
@@ -73,7 +73,7 @@ unsigned int RendererBuffer<T>::remainingCapacity() {
 template <>
 void RendererBuffer<Vertex>::enableAttributes() const {
     GLuint positionIdx = program->findProgramAttribute("vertex_point");
-    glVertexAttribIPointer(positionIdx, 2, GL_SHORT, sizeof(Vertex), (void*)offsetof(struct Vertex, point));
+    glVertexAttribIPointer(positionIdx, 3, GL_SHORT, sizeof(Vertex), (void*)offsetof(struct Vertex, point));
     glEnableVertexAttribArray(positionIdx);
 
     GLuint colorIdx = program->findProgramAttribute("vertex_color");

--- a/src/Vertex.cpp
+++ b/src/Vertex.cpp
@@ -57,9 +57,9 @@ Color::Color(uint32_t color) {
     b = ((GLubyte)((color >> 16) & 0xff));
 }
 
-Vertex::Vertex(Point3D point, Color color) : point(point), color(color), texturePosition(), textureBlendMode(), texturePage(), textureDepthShift(), clut() {}
+Vertex::Vertex(Point3D point, Color color, GLuint opaque) : point(point), color(color), transparent(!opaque), texturePosition(), textureBlendMode(), texturePage(), textureDepthShift(), clut() {}
 
-Vertex::Vertex(Point3D point, Color color, Point2D texturePosition, TextureBlendMode textureBlendMode, Point2D texturePage, GLuint textureDepthShift, Point2D clut) : point(point), color(color), texturePosition(texturePosition), textureBlendMode(textureBlendMode), texturePage(texturePage), textureDepthShift(textureDepthShift), clut(clut) {}
+Vertex::Vertex(Point3D point, Color color, GLuint opaque, Point2D texturePosition, TextureBlendMode textureBlendMode, Point2D texturePage, GLuint textureDepthShift, Point2D clut) : point(point), color(color),  transparent(!opaque), texturePosition(texturePosition), textureBlendMode(textureBlendMode), texturePage(texturePage), textureDepthShift(textureDepthShift), clut(clut) {}
 
 Vertex::~Vertex() {}
 

--- a/src/Vertex.cpp
+++ b/src/Vertex.cpp
@@ -41,15 +41,25 @@ Point2D Point2D::forClut(uint16_t clutData) {
     return {x, y};
 }
 
+Point3D::Point3D() : x(), y(), z() {}
+
+Point3D::Point3D(GLshort x, GLshort y, GLshort z) : x(x), y(y), z(z) {}
+
+Point3D::Point3D(uint32_t position) {
+    x = ((GLshort)(position & 0xffff));
+    y = ((GLshort)((position >> 16) & 0xffff));
+    z = 0;
+}
+
 Color::Color(uint32_t color) {
     r = ((GLubyte)(color & 0xff));
     g = ((GLubyte)((color >> 8) & 0xff));
     b = ((GLubyte)((color >> 16) & 0xff));
 }
 
-Vertex::Vertex(Point2D point, Color color) : point(point), color(color), texturePosition(), textureBlendMode(), texturePage(), textureDepthShift(), clut() {}
+Vertex::Vertex(Point3D point, Color color) : point(point), color(color), texturePosition(), textureBlendMode(), texturePage(), textureDepthShift(), clut() {}
 
-Vertex::Vertex(Point2D point, Color color, Point2D texturePosition, TextureBlendMode textureBlendMode, Point2D texturePage, GLuint textureDepthShift, Point2D clut) : point(point), color(color), texturePosition(texturePosition), textureBlendMode(textureBlendMode), texturePage(texturePage), textureDepthShift(textureDepthShift), clut(clut) {}
+Vertex::Vertex(Point3D point, Color color, Point2D texturePosition, TextureBlendMode textureBlendMode, Point2D texturePage, GLuint textureDepthShift, Point2D clut) : point(point), color(color), texturePosition(texturePosition), textureBlendMode(textureBlendMode), texturePage(texturePage), textureDepthShift(textureDepthShift), clut(clut) {}
 
 Vertex::~Vertex() {}
 

--- a/src/Vertex.cpp
+++ b/src/Vertex.cpp
@@ -1,16 +1,16 @@
 #include "Vertex.hpp"
 #include "GPU.hpp"
 
-Point::Point() : x(), y() {}
+Point2D::Point2D() : x(), y() {}
 
-Point::Point(GLshort x, GLshort y) : x(x), y(y) {}
+Point2D::Point2D(GLshort x, GLshort y) : x(x), y(y) {}
 
-Point::Point(uint32_t position) {
+Point2D::Point2D(uint32_t position) {
     x = ((GLshort)(position & 0xffff));
     y = ((GLshort)((position >> 16) & 0xffff));
 }
 
-Point Point::forTexturePosition(uint16_t position) {
+Point2D Point2D::forTexturePosition(uint16_t position) {
     GLshort texturePositonX = ((GLshort)(position & 0xff));
     GLshort texturePositionY = ((GLshort)((position >> 8) & 0xff));
     return {texturePositonX, texturePositionY};
@@ -23,7 +23,7 @@ Texture page:
 5-6   Semi Transparency     (0=B/2+F/2, 1=B+F, 2=B-F, 3=B+F/4)   ;GPUSTAT.5-6
 7-8   Texture page colors   (0=4bit, 1=8bit, 2=15bit, 3=Reserved);GPUSTAT.7-8
 */
-Point Point::forTexturePage(uint32_t texturePage) {
+Point2D Point2D::forTexturePage(uint32_t texturePage) {
     GLshort texturePageX = ((GLshort)((texturePage & 0xf) << 6));
     GLshort texturePageY = ((GLshort)(((texturePage >> 4) & 0x1) << 8));
     return {texturePageX, texturePageY};
@@ -35,7 +35,7 @@ CLUT:
 6-14     Y coordinate 0-511 (ie. in 1-line steps)
 15       Unknown/unused (should be 0)
 */
-Point Point::forClut(uint16_t clutData) {
+Point2D Point2D::forClut(uint16_t clutData) {
     GLshort x = ((GLshort)((clutData & 0x3f) << 4));
     GLshort y = ((GLshort)((clutData >> 6) & 0x1ff));
     return {x, y};
@@ -47,9 +47,9 @@ Color::Color(uint32_t color) {
     b = ((GLubyte)((color >> 16) & 0xff));
 }
 
-Vertex::Vertex(Point point, Color color) : point(point), color(color), texturePosition(), textureBlendMode(), texturePage(), textureDepthShift(), clut() {}
+Vertex::Vertex(Point2D point, Color color) : point(point), color(color), texturePosition(), textureBlendMode(), texturePage(), textureDepthShift(), clut() {}
 
-Vertex::Vertex(Point point, Color color, Point texturePosition, TextureBlendMode textureBlendMode, Point texturePage, GLuint textureDepthShift, Point clut) : point(point), color(color), texturePosition(texturePosition), textureBlendMode(textureBlendMode), texturePage(texturePage), textureDepthShift(textureDepthShift), clut(clut) {}
+Vertex::Vertex(Point2D point, Color color, Point2D texturePosition, TextureBlendMode textureBlendMode, Point2D texturePage, GLuint textureDepthShift, Point2D clut) : point(point), color(color), texturePosition(texturePosition), textureBlendMode(textureBlendMode), texturePage(texturePage), textureDepthShift(textureDepthShift), clut(clut) {}
 
 Vertex::~Vertex() {}
 


### PR DESCRIPTION
This fixes transparency and some texture blending modes in the OpenGL renderer. 

Tested with [RenderTexturePolygon15BPP.exe](https://github.com/PeterLemon/PSX/blob/master/GPU/16BPP/RenderTexturePolygon/15BPP/RenderTexturePolygon15BPP.png).

Before:
![Screenshot from 2020-05-18 22-30-48](https://user-images.githubusercontent.com/346590/82261949-50385280-9960-11ea-89b8-01fcd3f0c18f.png)
![Screenshot from 2020-05-18 23-32-49](https://user-images.githubusercontent.com/346590/82261976-5dedd800-9960-11ea-8246-a4e762ffea79.png)
After:
![Screenshot from 2020-05-18 22-37-14](https://user-images.githubusercontent.com/346590/82261955-529aac80-9960-11ea-833d-fac874b45f0e.png)
![Screenshot from 2020-05-18 23-30-14](https://user-images.githubusercontent.com/346590/82261986-634b2280-9960-11ea-8807-0d9d8ac605dd.png)


